### PR TITLE
Raise friendly error when template host cannot be resolved.

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -78,6 +78,8 @@ module Slimmer
       raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     rescue Errno::ECONNREFUSED => e
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+    rescue SocketError => e
+      raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     end
 
     def template_url template_name

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -40,4 +40,14 @@ class SkinTest < MiniTest::Unit::TestCase
       skin.load_template 'example'
     end
   end
+
+  def test_should_raise_appropriate_exception_when_hostname_cannot_be_resolved
+    skin = Slimmer::Skin.new asset_host: "http://non-existent.domain/"
+    expected_url = "http://non-existent.domain/templates/example.html.erb"
+    stub_request(:get, expected_url).to_raise(SocketError)
+
+    assert_raises(Slimmer::CouldNotRetrieveTemplate) do
+      skin.load_template 'example'
+    end
+  end
 end


### PR DESCRIPTION
By default, Rummager will attempt to connect to static.dev.gov.uk for
its templates.  If you're not using the standard hosts (*.dev.gov.uk)
to serve the apps then visiting your instance of Rummager will result
in the fairly opaque:

```
SocketError at /
getaddrinfo: nodename nor servname provided, or not known
```

This change to slimmer will catch the SocketError exception and raise a
more friendly Slimmer::CouldNotRetrieveTemplate error, which is what it
currently does when it can't connect to port 80.  This makes it much
easier to diagnose these problems in client apps, e.g. Rummager.
