### PR TITLE
Add Google Analytics tracking variables to GOVUK.

### DIFF
--- a/lib/slimmer/google_analytics_configurator.rb
+++ b/lib/slimmer/google_analytics_configurator.rb
@@ -29,7 +29,8 @@ module Slimmer
     def set_custom_var(slot, name, value)
       return nil unless value
       value.downcase!
-      "_gaq.push(#{JSON.dump([ "_setCustomVar", slot, name, value, PAGE_LEVEL_EVENT])});"
+      response = "_gaq.push(#{JSON.dump([ "_setCustomVar", slot, name, value, PAGE_LEVEL_EVENT])});\n"
+      response + "GOVUK.Analytics.#{name} = \"#{value}\";"
     end
   end
 end

--- a/test/fixtures/wrapper.html.erb
+++ b/test/fixtures/wrapper.html.erb
@@ -14,6 +14,8 @@
     </div>
 
     <script id="ga-params" type="text/javascript">
+      var GOVUK = GOVUK || {};
+      GOVUK.Analytics = GOVUK.Analytics || {};
       var _gaq = _gaq || [];
     </script>
   </body>

--- a/test/google_analytics_test.rb
+++ b/test/google_analytics_test.rb
@@ -22,12 +22,23 @@ module GoogleAnalyticsTest
       context.eval("_gaq");
     end
 
+    def govuk
+      js = Nokogiri::HTML(last_response.body).at_css("#ga-params").text
+      context = V8::Context.new
+      context.eval(js)
+      context.eval("GOVUK.Analytics");
+    end
+
     def assert_custom_var(slot, name, value, page_level)
       # Ruby Racer JS arrays don't accept range indexing, so we must
       # use a slightly longer workaround
       vars = gaq.select { |a| a[0] == "_setCustomVar" }.
                  map { |a| (1..4).map { |i| a[i] } }
       assert_includes vars, [slot, name, value, page_level]
+    end
+
+    def assert_set_var(name, value, object)
+      assert_equal value, object.find { |each| each[0] == name }[1]
     end
 
     def refute_custom_var(name)
@@ -54,20 +65,40 @@ module GoogleAnalyticsTest
       assert_custom_var 1, "Section", "rhubarb", PAGE_LEVEL_EVENT
     end
 
+    def test_should_set_section_in_GOVUK_object
+      assert_set_var "Section", "rhubarb", govuk
+    end
+
     def test_should_pass_internal_format_name_to_GA
       assert_custom_var 2, "Format", "custard", PAGE_LEVEL_EVENT
+    end
+
+    def test_should_set_section_in_GOVUK_object
+      assert_set_var "Format", "custard", govuk
     end
 
     def test_should_pass_need_ID_to_GA
       assert_custom_var 3, "NeedID", "42", PAGE_LEVEL_EVENT
     end
 
+    def test_should_set_section_in_GOVUK_object
+      assert_set_var "NeedID", "42", govuk
+    end
+
     def test_should_pass_proposition_to_GA
       assert_custom_var 4, "Proposition", "trifle", PAGE_LEVEL_EVENT
     end
 
+    def test_should_set_section_in_GOVUK_object
+      assert_set_var "Proposition", "trifle", govuk
+    end
+
     def test_should_pass_result_count_to_GA
       assert_custom_var 5, "ResultCount", "3", PAGE_LEVEL_EVENT
+    end
+
+    def test_should_set_section_in_GOVUK_object
+      assert_set_var "ResultCount", "3", govuk
     end
   end
 

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -65,7 +65,7 @@ module TypicalUsage
     }
 
     def test_should_set_correct_content_length_header
-      assert_equal "791", last_response.headers['Content-Length']
+      assert_equal "869", last_response.headers['Content-Length']
     end
 
   end


### PR DESCRIPTION
Add the Google Analytics tracking variables inserted by Slimmer to the
GOVUK.Analytics javascript namespace so that they can be used for guide
success tracking.
