### PR TITLE
Copy conditional comments to template.

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -22,6 +22,7 @@ module Slimmer
   autoload :AdminTitleInserter, 'slimmer/admin_title_inserter'
   autoload :SectionInserter, 'slimmer/section_inserter'
   autoload :TagMover, 'slimmer/tag_mover'
+  autoload :ConditionalCommentMover, 'slimmer/conditional_comment_mover'
   autoload :FooterRemover, 'slimmer/footer_remover'
   autoload :BodyInserter, 'slimmer/body_inserter'
   autoload :BodyClassCopier, 'slimmer/body_class_copier'

--- a/lib/slimmer/conditional_comment_mover.rb
+++ b/lib/slimmer/conditional_comment_mover.rb
@@ -1,0 +1,17 @@
+module Slimmer
+  class ConditionalCommentMover
+    def filter(src, dest)
+      src.xpath('//comment()').each do |comment|
+        if match_conditional_comments(comment)
+          dest.at_xpath('/html/head') << comment
+        end
+      end
+    end
+
+    def match_conditional_comments(str)
+      str.to_s =~ /<!--\[[A-Za-z0-9 ]+\]>(.*)<!\[endif\]-->/m
+    end
+  end
+end
+
+

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -125,6 +125,7 @@ module Slimmer
       processors = [
         TitleInserter.new(),
         TagMover.new(),
+        ConditionalCommentMover.new(),
         BodyInserter.new(options[:wrapper_id] || 'wrapper'),
         BodyClassCopier.new,
         HeaderContextInserter.new(),

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -78,6 +78,7 @@ module TypicalUsage
       <meta name="x-section-name" content="This section">
       <meta name="x-section-link" content="/this_section">
       <script src="blah.js"></script>
+      <!--[if lt IE 9]><link href="app-ie.css" rel="stylesheet" type="text/css"><![endif]-->
       <link href="app.css" rel="stylesheet" type="text/css">
       </head>
       <body class="body_class">
@@ -104,6 +105,11 @@ module TypicalUsage
 
     def test_should_move_stylesheet_tags_into_the_head
       assert_rendered_in_template "head link[href='app.css']"
+    end
+
+    def test_should_move_conditional_comments_into_the_head
+      element = Nokogiri::HTML.parse(last_response.body).at_xpath('//comment()')
+      assert_match /app-ie\.css/, element.to_s, 'Not found conditional comment in output'
     end
 
     def test_should_copy_the_class_of_the_body_element


### PR DESCRIPTION
Conditional comments are the safest way of targeting specific IE
versions. As in inside government we are using SCSS to precompile our
CSS we can very easily create a desecrate version of stylesheets
targeting individual IEs.

After speaking with James Weiner he was in agreement that this would
also be a good way of stripping out our media queries to serve a
desktop sized stylesheet to IE while serving @media selectors to modern
browsers.

Added a new class to look at comments and find ones structured as an IE
conditional comment. Then move these accross to the template. Added a
test to check this.
