### PR TITLE
Conditional comments

### DIFF
--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -134,7 +134,7 @@ module TypicalUsage
     given_response 200, %{
       <html>
       <head>
-      <!--[if gt IE 8]>--><link href="app.css" rel="stylesheet" type="text/css" slimmer-wrap-with="gt IE 8"><!--<![endif]-->
+      <!--[if gt IE 8]>--><link href="app.css" rel="stylesheet" type="text/css"><!--<![endif]-->
       </head>
       </html>
     }


### PR DESCRIPTION
Being able to wrap tags with conditional comments will let us ensure we
don't serve modern stylesheets to old IE in the case where we are
serving them their own IE only stylesheet.

Added a proprietary attribute which takes the condition to add to the
comment in the form `slimmer-wrap-with="[condition]"`. This will then 
copy that tag across and re-wrap it with conditional comments as the
comments don't get copied by slimmer.
