### PR TITLE
Use mainstream class in related items inserter

### DIFF
--- a/lib/slimmer/related_items_inserter.rb
+++ b/lib/slimmer/related_items_inserter.rb
@@ -15,8 +15,8 @@ class Slimmer::RelatedItemsInserter
   end
   
   def filter(content_document, page_template)
-    if content_document.at_css('body.citizen div#related-items')
-      page_template.at_css('body.citizen div#related-items').replace(related_item_block)
+    if content_document.at_css('body.mainstream div#related-items')
+      page_template.at_css('body.mainstream div#related-items').replace(related_item_block)
     end
   end
   

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -166,10 +166,10 @@ module TypicalUsage
     end
   end
 
-  class CitizenRelatedItemsTest < ResponseWithRelatedItemsTest
+  class MainstreamRelatedItemsTest < ResponseWithRelatedItemsTest
     given_response 200, %{
       <html>
-      <body class="citizen">
+      <body class="mainstream">
       <div id="wrapper">The body of the page<div id="related-items"></div></div>
       </body>
       </html>
@@ -185,10 +185,10 @@ module TypicalUsage
     end
   end
 
-  class NonCitizentRelatedItemsTest < ResponseWithRelatedItemsTest
+  class NonMainstreamRelatedItemsTest < ResponseWithRelatedItemsTest
     given_response 200, %{
       <html>
-      <body class="noncitizen">
+      <body class="nonmainstream">
       <div id="wrapper">The body of the page<div id="related-items"></div></div>
       </body>
       </html>
@@ -330,7 +330,7 @@ module TypicalUsage
       <script src="blah.js"></script>
       <link href="app.css" rel="stylesheet" type="text/css">
       </head>
-      <body class="body_class citizen">
+      <body class="body_class mainstream">
       <div id="wrapper">The body of the page</div>
       <div id="related-items"></div>
       </body>


### PR DESCRIPTION
The citizen class is deprecated (replaced with mainstream).
