### PR TITLE
Recursively parse tags into breadcrumbs

### DIFF
--- a/lib/slimmer/processors/section_inserter.rb
+++ b/lib/slimmer/processors/section_inserter.rb
@@ -4,16 +4,30 @@ module Slimmer::Processors
       @artefact = artefact
     end
 
-    def filter(src,dest)
+    def filter(src, dest)
       if @artefact and (list = dest.at_css('.header-context nav[role=navigation] ol'))
         if (section = @artefact.primary_section)
-          append_tag(list, section["parent"]) if section["parent"]
-          append_tag(list, section, :strong => true)
+          sections = recurse_sections(section)
+          current = sections.pop
+          sections.each do |section|
+            append_tag(list, section)
+          end
+          append_tag(list, current, :strong => true)
         end
       end
     end
 
     private
+
+    def recurse_sections(section, current = nil)
+      current = [section] unless current
+
+      if section['parent']
+        current.unshift(section['parent'])
+        current = recurse_sections(section['parent'], current)
+      end
+      current
+    end
 
     def append_tag(list, tag, opts = {})
       link_node = Nokogiri::XML::Node.new('a', list)

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock', '~> 1.7'
   s.add_development_dependency 'therubyracer'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
-  s.add_development_dependency 'gds-api-adapters', '1.9.2'
+  s.add_development_dependency 'gds-api-adapters', '2.7.1'
   s.add_development_dependency 'timecop', '~> 0.5.1'
   s.files         = Dir[
     'README.md',

--- a/test/processors/section_inserter_test.rb
+++ b/test/processors/section_inserter_test.rb
@@ -146,4 +146,34 @@ class SectionInserterTest < MiniTest::Unit::TestCase
     list = template.at_css(".header-context nav[role=navigation] ol")
     assert_in list, "li:nth-child(1)", %{<a href="/">Home</a>}
   end
+
+  def test_should_support_multiple_levels_of_navigation
+    artefact = create_artefact("something",
+                               "section_slug" => "business",
+                               "subsection_slug" => "employing-people/deep-section")
+
+    template = as_nokogiri %{
+      <html>
+        <body>
+          <div class="header-context">
+            <nav role="navigation">
+              <ol class="group">
+                <li><a href="/">Home</a></li>
+                <li><a href="/browse">All Sections</a></li>
+              </ol>
+            </nav>
+          </div>
+        </body>
+      </html>
+    }
+
+    Slimmer::Processors::SectionInserter.new(artefact).filter(:any_source, template)
+    list = template.at_css(".header-context nav[role=navigation] ol")
+    assert_in list, "li:nth-child(1)", %{<a href="/">Home</a>}
+    assert_in list, "li:nth-child(2)", %{<a href="/browse">All Sections</a>}
+    assert_in list, "li:nth-child(3)", %{<a href="https://www.test.gov.uk/browse/business">Business</a>}
+    assert_in list, "li:nth-child(4)", %{<a href="https://www.test.gov.uk/browse/business/employing-people">Employing people</a>}
+    assert_in list, "li:nth-child(5)", %{<strong><a href="https://www.test.gov.uk/browse/business/employing-people/deep-section">Deep section</a></strong>}
+  end
+
 end


### PR DESCRIPTION
This is required to bring specialist guidance and detailed categories into the breadcrumb navigation tree.

This allows us to build up a list of breadcrumbs > 2 in length by recursing the `parent` attribute of each tag. Previously it only supported a single level of depth.

The update to `gds-api-adapters` is needed so that the added test can pass.
