### PR TITLE
Include parent tag in dummy artefact helper

### DIFF
--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -47,6 +47,12 @@ module Slimmer
           "details" => {"type" => "section"},
           "content_with_tag" => {"web_url" => details[:section_link]},
         }
+        if details[:parent]
+          tag["parent"] = {"title" => details[:parent][:section_name],
+                            "details" => {"type" => "section"},
+                            "content_with_tag" => {"web_url" => details[:parent][:section_link]},
+                          }
+        end
         artefact["tags"] = [tag]
       end
       headers[ARTEFACT_HEADER] = artefact.to_json


### PR DESCRIPTION
Needed to generate the sub category breadcrumb in the browse pages.

FYI: I am aware that there is no test to cover this, it's on my todo list to be added later.
