### PR TITLE
Restore previous nil header behaviour

### DIFF
--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -12,13 +12,13 @@ module Slimmer::Processors
     def filter(src, dest)
       custom_vars = []
       if @artefact
-        custom_vars << set_custom_var(1, "Section", @artefact.primary_root_section["title"].downcase) if @artefact.primary_root_section
-        custom_vars << set_custom_var(3, "NeedID", @artefact.need_id.downcase)
-        custom_vars << set_custom_var(4, "Proposition", (@artefact.business_proposition ? 'business' : 'citizen')) unless @artefact.business_proposition.nil?
+        custom_vars << set_custom_var_downcase(1, "Section", @artefact.primary_root_section["title"]) if @artefact.primary_root_section
+        custom_vars << set_custom_var_downcase(3, "NeedID", @artefact.need_id)
+        custom_vars << set_custom_var_downcase(4, "Proposition", (@artefact.business_proposition ? 'business' : 'citizen')) unless @artefact.business_proposition.nil?
         custom_vars << set_custom_var(9, "Organisations", @artefact.organisations) unless @artefact.organisations.nil?
       end
-      custom_vars << set_custom_var(2, "Format", @headers[Slimmer::Headers::FORMAT_HEADER].downcase)
-      custom_vars << set_custom_var(5, "ResultCount", @headers[Slimmer::Headers::RESULT_COUNT_HEADER].downcase)
+      custom_vars << set_custom_var_downcase(2, "Format", @headers[Slimmer::Headers::FORMAT_HEADER])
+      custom_vars << set_custom_var_downcase(5, "ResultCount", @headers[Slimmer::Headers::RESULT_COUNT_HEADER])
 
       if dest.at_css("#ga-params")
         dest.at_css("#ga-params").content += custom_vars.compact.join("\n")
@@ -26,8 +26,12 @@ module Slimmer::Processors
     end
 
   private
-    def set_custom_var(slot, name, value)
+    def set_custom_var_downcase(slot, name, value)
       return nil unless value
+      set_custom_var(slot, name, value.downcase)
+    end
+
+    def set_custom_var(slot, name, value)
       response = "_gaq.push(#{JSON.dump([ "_setCustomVar", slot, name, value, PAGE_LEVEL_EVENT])});\n"
       response + "GOVUK.Analytics.#{name} = \"#{value}\";"
     end

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -2,6 +2,7 @@ require_relative "../test_helper"
 require "v8"
 
 module GoogleAnalyticsTest
+  PAGE_LEVEL_EVENT = 3
 
   GENERIC_DOCUMENT = <<-END
     <html>
@@ -49,7 +50,6 @@ module GoogleAnalyticsTest
 
   class WithHeadersTest < SlimmerIntegrationTest
     include JavaScriptAssertions
-    PAGE_LEVEL_EVENT = 3
 
     def setup
       super
@@ -97,7 +97,7 @@ module GoogleAnalyticsTest
       assert_custom_var 4, "Proposition", "business", PAGE_LEVEL_EVENT
     end
 
-    def test_should_pass_proposition_to_GA
+    def test_should_pass_organisation_to_GA
       assert_custom_var 9, "Organisations", "<P1><D422>", PAGE_LEVEL_EVENT
     end
 
@@ -141,6 +141,31 @@ module GoogleAnalyticsTest
 
     def test_should_omit_result_count
       refute_custom_var "ResultCount"
+    end
+  end
+
+  class WithNilHeaderTest < SlimmerIntegrationTest
+    include JavaScriptAssertions
+
+    def setup
+      super
+
+      artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
+      artefact["details"].merge!(
+        "need_id" => "42",
+        "business_proposition" => true,
+        "organisations" => "<P1><D422>"
+      )
+      headers = {
+        Slimmer::Headers::RESULT_COUNT_HEADER => "3",
+        Slimmer::Headers::ARTEFACT_HEADER => artefact.to_json
+      }
+
+      given_response 200, GENERIC_DOCUMENT, headers
+    end
+
+    def test_should_pass_organisation_to_GA_without_crashing
+      assert_custom_var 9, "Organisations", "<P1><D422>", PAGE_LEVEL_EVENT
     end
   end
 end


### PR DESCRIPTION
Unfortunately the previous set of comments changed the semantics of the handling of nil
headers, which throws an exception and prevents the custom variables
from being sent at all under certain conditions. This commit restores those semantics.
