### PR TITLE
Don't interfere with non-html response bodies.

### DIFF
--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -47,6 +47,25 @@ module TypicalUsage
     end
   end
 
+  class SkipDoesntInteractWithNonHtmlBodies < SlimmerIntegrationTest
+    def test_non_html_response_bodies_are_passed_through_untouched
+      # Rack::SendFile doesn't work if to_s, to_str or each are called on the
+      # response body (as happens when building a Rack::Response)
+      body = stub('body')
+      inner_app = proc { |env|
+        [200, {"Content-Type" => "application/json"}, body]
+      }
+      app = Slimmer::App.new inner_app, {asset_host: "http://template.local"}
+
+      body.expects(:to_s).never
+      body.expects(:to_str).never
+      body.expects(:each).never
+      Rack::Response.expects(:new).never
+
+      app.call({})
+    end
+  end
+
   class ContentLengthTest < SlimmerIntegrationTest
     given_response 200, %{
       <html>


### PR DESCRIPTION
Trying to get whitehall to serve uploaded attachments using
send_file in rails fails on apps using slimmer.  After a fair amount
of debugging, I traced the cause to the use of the Rack::Response
object to query the response.  Constructing a Rack::Response starts
building a new response, interacting with the original body in a way
that breaks the Rack::SendFile middleware.

N.B. The included test deliberately doesn't use rack-test (calling
the app directly), as rack-test itself constructs responses and
calls methods on the body - exactly the things we're trying to
prevent.
