### PR TITLE
use 'static' not 'assets'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ various other details, such as meta, script, and style tags.
 ## Use in a Rails app
 
 Slimmer provides a Railtie so no configuration is necessary. By default it will use the
-Plek gem to look for the 'assets' host for the current environment.
+Plek gem to look for the 'static' (previously 'assets') host for the current environment.
 
 If you want to use your own set of templates you will need to specify the appropriate host
 eg.

--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -23,7 +23,7 @@ module Slimmer
       end
 
       unless options[:asset_host]
-        options[:asset_host] = Plek.current.find("assets")
+        options[:asset_host] = Plek.current.find("static")
       end
 
       @skin = Skin.new options.merge(logger: self.logger)


### PR DESCRIPTION
This change is non-breaking and while using old Plek, calling `Plek.current.find('static')` is the same as calling `Plek.current.find('assets')`. Using 'assets' with new Plek (v1.0.0) will return `assets.$GOVUK_APP_DOMAIN` which is incorrect, hence the need for this change when dependent apps are using Plek 1.0.0.
