### PR TITLE
Use a hidden field to set the default search tab

### DIFF
--- a/lib/slimmer/processors/search_index_setter.rb
+++ b/lib/slimmer/processors/search_index_setter.rb
@@ -10,15 +10,18 @@ module Slimmer::Processors
 
     def filter(content_document, page_template)
       if search_index && (form = page_template.at_css('form#search'))
-        uri = URI(form['action'])
-        uri.fragment = search_index_fragment
-        form['action'] = uri.to_s
+        input_html = Nokogiri::HTML.fragment(tab_input_tag)
+        form.add_child(input_html)
       end
     end
 
     private
 
-    def search_index_fragment
+    def tab_input_tag
+      %Q{<input type="hidden" name="tab" value="#{search_index_tab}">}
+    end
+
+    def search_index_tab
       "#{search_index}-results"
     end
 

--- a/test/processors/search_index_setter_test.rb
+++ b/test/processors/search_index_setter_test.rb
@@ -23,8 +23,8 @@ module SearchIndexSetterTest
     given_response 200, DOCUMENT_WITH_SEARCH, headers
 
     def test_should_insert_index_field
-      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')['action']
-      assert_equal "/path/to/search#government-results", search_action
+      search_tab_field = Nokogiri::HTML.parse(last_response.body).at_css('input')['value']
+      assert_equal "government-results", search_tab_field
     end
   end
 
@@ -32,7 +32,8 @@ module SearchIndexSetterTest
     given_response 200, DOCUMENT_WITH_SEARCH, {}
 
     def test_should_not_insert_index_field
-      assert_equal Nokogiri::HTML.parse(last_response.body).at_css('#search')['action'], '/path/to/search'
+      search_tab_field = Nokogiri::HTML.parse(last_response.body).css('input')
+      assert_equal 0, search_tab_field.length
     end
   end
 end


### PR DESCRIPTION
Search now has a hidden field which you can set the default tab using.
This is due to IE not passing fragment identifiers through when
submitting a form.
