### PR TITLE
Tweak location of beta notice to be directly after header

### DIFF
--- a/lib/slimmer/processors/beta_notice_inserter.rb
+++ b/lib/slimmer/processors/beta_notice_inserter.rb
@@ -8,8 +8,8 @@ module Slimmer::Processors
     def filter(content_document, page_template)
       if should_add_beta_notice?
         page_template.css('body').add_class('beta')
-        if cookie_bar = page_template.at_css('#global-cookie-message')
-          cookie_bar.add_next_sibling(beta_notice_block)
+        if header = page_template.at_css('#global-header')
+          header.add_next_sibling(beta_notice_block)
         end
         if footer = page_template.at_css('footer#footer')
           footer.add_previous_sibling(beta_notice_block)

--- a/lib/slimmer/test_template.rb
+++ b/lib/slimmer/test_template.rb
@@ -7,7 +7,8 @@ module Slimmer::TestTemplate
         <script src="https://static.preview.alphagov.co.uk/static/application.js" type="text/javascript" defer="defer"></script>
       </head>
       <body>
-        <div class="header-context">
+        <header id="global-header"><header>
+        <div id="global-navigation" class="header-context">
           <nav role="navigation">
             <ol class="group">
               <li><a href="/">Home</a></li>
@@ -16,6 +17,8 @@ module Slimmer::TestTemplate
         </div>
 
         <div id="wrapper"></div>
+
+        <footer id="footer"></footer>
       </body>
     </html>
   }

--- a/test/fixtures/wrapper.html.erb
+++ b/test/fixtures/wrapper.html.erb
@@ -9,11 +9,9 @@
     </script>
   </head>
   <body>
-    <header><h1>I AM A TITLE</h1></header>
+    <header id="global-header"><h1>I AM A TITLE</h1></header>
 
-    <div id="global-cookie-message"></div>
-
-    <div class="header-context">
+    <div id="global-navigation" class="header-context">
       <nav role="navigation"><ol><li>MySite</li></ol></nav>
     </div>
 

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -264,7 +264,7 @@ module TypicalUsage
       }, {Slimmer::Headers::BETA_HEADER => '1'}
 
       # beta notice after cookie bar
-      assert_rendered_in_template "body.beta.wibble #global-cookie-message + div.beta-notice"
+      assert_rendered_in_template "body.beta.wibble #global-header + div.beta-notice"
 
       # beta notice before footer
       assert_rendered_in_template "body.beta.wibble div.beta-notice + #footer"


### PR DESCRIPTION
Had to update the test templates again to add the relevant ids to match
current preview.
