### PR TITLE
Add navigation mover

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -34,6 +34,7 @@ module Slimmer
     autoload :GoogleAnalyticsConfigurator, 'slimmer/processors/google_analytics_configurator'
     autoload :HeaderContextInserter, 'slimmer/processors/header_context_inserter'
     autoload :LogoClassInserter, 'slimmer/processors/logo_class_inserter'
+    autoload :NavigationMover, 'slimmer/processors/navigation_mover'
     autoload :MetaViewportRemover, 'slimmer/processors/meta_viewport_remover'
     autoload :RelatedItemsInserter, 'slimmer/processors/related_items_inserter'
     autoload :ReportAProblemInserter, 'slimmer/processors/report_a_problem_inserter'

--- a/lib/slimmer/processors/navigation_mover.rb
+++ b/lib/slimmer/processors/navigation_mover.rb
@@ -1,0 +1,25 @@
+class Slimmer::Processors::NavigationMover
+
+  def initialize(skin)
+    @skin = skin
+  end
+
+  def filter(src, dest)
+    proposition_header = src.at_css("#proposition-menu")
+    global_header = dest.at_css("#global-header")
+    if proposition_header && global_header
+      proposition_header.remove
+
+      global_header['class'] = [global_header['class'], 'with-proposition'].compact.join(' ')
+
+      header_block = Nokogiri::HTML.fragment(proposition_header_block)
+      header_block.at_css('.content') << proposition_header
+
+      global_header.at_css('.header-wrapper') << header_block
+    end
+  end
+
+  def proposition_header_block
+    @proposition_header_block ||= @skin.template('proposition_menu')
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -117,6 +117,7 @@ module Slimmer
       processors = [
         Processors::TitleInserter.new(),
         Processors::TagMover.new(),
+        Processors::NavigationMover.new(self),
         Processors::ConditionalCommentMover.new(),
         Processors::BodyInserter.new(options[:wrapper_id] || 'wrapper'),
         Processors::BodyClassCopier.new,

--- a/test/fixtures/proposition_menu.html.erb
+++ b/test/fixtures/proposition_menu.html.erb
@@ -1,0 +1,7 @@
+<div class="header-proposition">
+  <div class="content">
+    <nav id="proposition-menu">
+      <a href="#">Navigation item</a>
+    </nav>
+  </div>
+</div>

--- a/test/processors/navigation_mover_test.rb
+++ b/test/processors/navigation_mover_test.rb
@@ -1,0 +1,53 @@
+require_relative '../test_helper'
+
+class NavigationMoverTest < MiniTest::Unit::TestCase
+  def setup
+    super
+    @proposition_header_block = File.read( File.dirname(__FILE__) + "/../fixtures/proposition_menu.html.erb" )
+    @skin = stub("Skin", :template => @proposition_header_block)
+  end
+  
+  def test_should_add_proposition_menu
+    source = as_nokogiri %{
+      <html>
+        <body>
+          <div id="proposition-menu"></div>
+        </body>
+      </html>
+    }
+    template = as_nokogiri %{
+      <html>
+        <body>
+          <div id="global-header"><div class="header-wrapper"></div></div>
+          <div id="wrapper"></div>
+        </body>
+      </html>
+    }
+
+    Slimmer::Processors::NavigationMover.new(@skin).filter(source, template)
+    assert_in template, "div#global-header.with-proposition"
+    assert_in template, "div#global-header #proposition-menu a", "Navigation item"
+  end
+
+  def test_should_not_add_proposition_menu_if_not_in_source
+    source = as_nokogiri %{
+      <html>
+        <body>
+          <div id="wrapper"></div>
+        </body>
+      </html>
+    }
+    template = as_nokogiri %{
+      <html>
+        <body>
+          <div id="global_header"><div class="header-wrapper"></div></div>
+          <div id="wrapper"></div>
+        </body>
+      </html>
+    }
+
+    @skin.expects(:template).never # Shouldn't fetch template when not inserting block
+    Slimmer::Processors::NavigationMover.new(@skin).filter(source, template)
+    assert_not_in template, "div#proposition_menu"
+  end
+end


### PR DESCRIPTION
This will take a navigation object from the source page and move it into
a supplied template before pasting that whole template into the
desination template.

This will require alphagov/static#212 to be merged before apps can take advantage of this due to the way it needs a template that static provides. However, that shouldn't block this as it will be dormant until an app tries to use it.
