### PR TITLE
Remove remaining CampaignNotificationInserter uses

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -29,7 +29,6 @@ module Slimmer
     autoload :BodyClassCopier, 'slimmer/processors/body_class_copier'
     autoload :BodyInserter, 'slimmer/processors/body_inserter'
     autoload :ConditionalCommentMover, 'slimmer/processors/conditional_comment_mover'
-    autoload :CampaignNotificationInserter, 'slimmer/processors/campaign_notification_inserter'
     autoload :FooterRemover, 'slimmer/processors/footer_remover'
     autoload :GoogleAnalyticsConfigurator, 'slimmer/processors/google_analytics_configurator'
     autoload :HeaderContextInserter, 'slimmer/processors/header_context_inserter'

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -7,7 +7,6 @@ module Slimmer
     SLIMMER_HEADER_MAPPING = {
       application_name:     "Application-Name",
       beta:                 "Beta",
-      campaign_notification:"Campaign-Notification",
       format:               "Format",
       need_id:              "Need-ID",
       page_owner:           "Page-Owner",
@@ -23,7 +22,6 @@ module Slimmer
     APPLICATION_NAME_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:application_name]}"
     ARTEFACT_HEADER = "#{HEADER_PREFIX}-Artefact"
     BETA_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:beta]}"
-    CAMPAIGN_NOTIFICATION = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:campaign_notification]}"
     FORMAT_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:format]}"
     ORGANISATIONS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:organisations]}"
     PAGE_OWNER_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:page_owner]}"

--- a/lib/slimmer/test_templates/campaign.html
+++ b/lib/slimmer/test_templates/campaign.html
@@ -1,1 +1,0 @@
-<section class="black" id="campaign-notification"><div><p>Notifications!</p></div></section>

--- a/test/fixtures/campaign.html.erb
+++ b/test/fixtures/campaign.html.erb
@@ -1,1 +1,0 @@
-<section id="campaign-notification"><p>testing...</p></section>

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -73,15 +73,6 @@ class HeadersTest < MiniTest::Unit::TestCase
     set_slimmer_headers remove_meta_viewport: true
     assert_equal "true", headers["X-Slimmer-Remove-Meta-Viewport"]
   end
-
-  def test_should_not_have_campaign_notification_set
-    assert_equal nil, headers["X-Slimmer-Campaign-Notification"]
-  end
-
-  def test_should_set_campaign_notification_header
-    set_slimmer_headers campaign_notification: true
-    assert_equal "true", headers["X-Slimmer-Campaign-Notification"]
-  end
 end
 
 describe Slimmer::Headers do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -78,7 +78,6 @@ class SlimmerIntegrationTest < MiniTest::Unit::TestCase
     use_template('related.raw')
     use_template('report_a_problem.raw')
     use_template('beta_notice')
-    use_template('campaign')
 
     fetch_page
   end


### PR DESCRIPTION
This clean up was left over from pull request #46. Having it left in
would cause 500 errors as slimmer would try to autoload a class was
deleted.
