### PR TITLE
Remove horrible hack relating to noscript tags.

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -107,9 +107,7 @@ module Slimmer
       end_time = Time.now
       logger.debug "Slimmer: Skinning process completed at #{end_time} (#{end_time - start_time}s)"
 
-      # this is a horrible fix to Nokogiri removing the closing </noscript> tag required by Google Website Optimizer.
-      # http://www.google.com/support/websiteoptimizer/bin/answer.py?hl=en_us&answer=64418
-      dest.to_html.sub(/<noscript rel=("|')placeholder("|')>/, "")
+      dest.to_html
     end
 
     def success(source_request, response, body)


### PR DESCRIPTION
There's nothing in our codebase that contains a noscript tag with a rel="placeholder" any more.  Also, the google link is now a 404, so things have probably moved on since then.
