### PR TITLE
Fix test templates asset-host

### DIFF
--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -16,12 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://static.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://static.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script defer src="https://static.preview.alphagov.co.uk/static/libs/jquery/plugins/jquery.base64.js?body=1" type="text/javascript"></script>
-    <script defer src="https://static.preview.alphagov.co.uk/static/user-satisfaction-survey.js?body=1" type="text/javascript"></script>
-    <script defer src="https://static.preview.alphagov.co.uk/static/core.js?body=1" type="text/javascript"></script>
-    <script defer src="https://static.preview.alphagov.co.uk/static/report-a-problem.js?body=1" type="text/javascript"></script>
-    <script src="https://static.preview.alphagov.co.uk/static/header-footer-only.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/header-footer-only.js" type="text/javascript"></script>
   </body>
 </html>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -16,8 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://static.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://static.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script src="https://static.preview.alphagov.co.uk/static/application.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets-origin.preview.alphagov.co.uk/static/application.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
Everything is now pointed as assets-origin instead of static.  Direct access to static from outside the stack is deprecated

This also removes the spurious JS includes from header_footer_only that were added in 1c3916e
