### PR TITLE
Remove an unnecessary ERB pass over fetched templates.

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -34,13 +34,7 @@ module Slimmer
       headers = {}
       headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
       response = RestClient.get(url, headers)
-      source = response.body
-      if template_name =~ /\.raw/
-        template = source
-      else
-        template = ERB.new(source).result binding
-      end
-      template
+      response.body
     rescue RestClient::Exception => e
       raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     rescue Errno::ECONNREFUSED => e


### PR DESCRIPTION
The only templates returned from static with ERB tags in them are the .raw ones, because they're used by various processors (that do their own ERB processing).  This block is therefore only running plain html through ERB, which is pointless.
