### PR TITLE
Pass Worldwide Location from headers to GA

### DIFF
--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -12,6 +12,7 @@ module Slimmer
       page_owner:           "Page-Owner",
       proposition:          "Proposition",
       organisations:        "Organisations",
+      worldwide_locations:  "Worldwide-Locations",
       remove_meta_viewport: "Remove-Meta-Viewport",
       result_count:         "Result-Count",
       section:              "Section",
@@ -24,6 +25,7 @@ module Slimmer
     BETA_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:beta]}"
     FORMAT_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:format]}"
     ORGANISATIONS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:organisations]}"
+    WORLDWIDE_LOCATIONS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:worldwide_locations]}"
     PAGE_OWNER_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:page_owner]}"
     REMOVE_META_VIEWPORT = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_meta_viewport]}"
     RESULT_COUNT_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:result_count]}"

--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -17,6 +17,7 @@ module Slimmer::Processors
         custom_vars << set_custom_var_downcase(4, "Proposition", (@artefact.business_proposition ? 'business' : 'citizen')) unless @artefact.business_proposition.nil?
       end
       custom_vars << set_custom_var(9, "Organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER])
+      custom_vars << set_custom_var(10, "WorldwideLocations", @headers[Slimmer::Headers::WORLDWIDE_LOCATIONS_HEADER])
       custom_vars << set_custom_var_downcase(2, "Format", @headers[Slimmer::Headers::FORMAT_HEADER])
       custom_vars << set_custom_var_downcase(5, "ResultCount", @headers[Slimmer::Headers::RESULT_COUNT_HEADER])
 

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -63,7 +63,8 @@ module GoogleAnalyticsTest
         Slimmer::Headers::FORMAT_HEADER => "custard",
         Slimmer::Headers::RESULT_COUNT_HEADER => "3",
         Slimmer::Headers::ARTEFACT_HEADER => artefact.to_json,
-        Slimmer::Headers::ORGANISATIONS_HEADER => "<P1><D422>"
+        Slimmer::Headers::ORGANISATIONS_HEADER => "<P1><D422>",
+        Slimmer::Headers::WORLDWIDE_LOCATIONS_HEADER => "<WL3>"
       }
 
       given_response 200, GENERIC_DOCUMENT, headers
@@ -99,6 +100,10 @@ module GoogleAnalyticsTest
 
     def test_should_pass_organisation_to_GA
       assert_custom_var 9, "Organisations", "<P1><D422>", PAGE_LEVEL_EVENT
+    end
+
+    def test_should_pass_worldwide_location_to_GA
+      assert_custom_var 10, "WorldwideLocations", "<WL3>", PAGE_LEVEL_EVENT
     end
 
     def test_should_set_section_in_GOVUK_object


### PR DESCRIPTION
support for x-slimmer-worldwide-locations
header passed to slimmer, the value of which
it sends to Google Analytics. this helps track
content that's tied to Worldwide Locations.
