### PR TITLE
Change from Beta Header to new Beta Notice

### DIFF
--- a/lib/slimmer/processors/beta_notice_inserter.rb
+++ b/lib/slimmer/processors/beta_notice_inserter.rb
@@ -7,24 +7,12 @@ module Slimmer::Processors
 
     def filter(content_document, page_template)
       if should_add_beta_notice?
-        page_template.css('body').add_class('beta')
-        if header = page_template.at_css('#global-header')
-          header.add_next_sibling(beta_notice_block)
-        end
-        if footer = page_template.at_css('footer#footer')
-          footer.add_previous_sibling(add_footer_class(beta_notice_block))
-        end
+        page_template.at_css('body div#beta-notice').replace(beta_notice_block)
       end
     end
 
     def should_add_beta_notice?
       !! @headers[Slimmer::Headers::BETA_HEADER]
-    end
-
-    def add_footer_class(block)
-      block = Nokogiri::HTML.fragment(block)
-      block.child['class'] = "#{block.child['class']} js-footer"
-      block
     end
 
     def beta_notice_block


### PR DESCRIPTION
In order to display to the user that the current page is in Beta, we can now include an element with an id attribute of beta-notice, which Slimmer will replace with the template in Static. Counterpart to a https://github.com/alphagov/static/pull/381. 
