### PR TITLE
Report multiple need ids to Google analytics

### DIFF
--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -13,7 +13,7 @@ module Slimmer::Processors
       custom_vars = []
       if @artefact
         custom_vars << set_custom_var_downcase(1, "Section", @artefact.primary_root_section["title"]) if @artefact.primary_root_section
-        custom_vars << set_custom_var_downcase(3, "NeedID", @artefact.need_id)
+        custom_vars << set_multivalue_custom_var(3, "NeedID", @artefact.need_ids)
         custom_vars << set_custom_var_downcase(4, "Proposition", (@artefact.business_proposition ? 'business' : 'citizen')) unless @artefact.business_proposition.nil?
       end
       custom_vars << set_custom_var(9, "Organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER])
@@ -30,6 +30,11 @@ module Slimmer::Processors
     def set_custom_var_downcase(slot, name, value)
       return nil unless value
       set_custom_var(slot, name, value.downcase)
+    end
+
+    def set_multivalue_custom_var(slot, name, values)
+      return nil if values.empty?
+      set_custom_var(slot, name, values.join(',').downcase)
     end
 
     def set_custom_var(slot, name, value)

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -56,7 +56,7 @@ module GoogleAnalyticsTest
 
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
       artefact["details"].merge!(
-        "need_id" => "42",
+        "need_ids" => [100001,100002],
         "business_proposition" => true,
       )
       headers = {
@@ -86,12 +86,12 @@ module GoogleAnalyticsTest
       assert_set_var "Format", "custard", govuk
     end
 
-    def test_should_pass_need_ID_to_GA
-      assert_custom_var 3, "NeedID", "42", PAGE_LEVEL_EVENT
+    def test_should_pass_need_ids_to_GA
+      assert_custom_var 3, "NeedID", "100001,100002", PAGE_LEVEL_EVENT
     end
 
-    def test_should_set_need_id_in_GOVUK_object
-      assert_set_var "NeedID", "42", govuk
+    def test_should_set_need_ids_in_GOVUK_object
+      assert_set_var "NeedID", "100001,100002", govuk
     end
 
     def test_should_pass_proposition_to_GA
@@ -157,7 +157,7 @@ module GoogleAnalyticsTest
 
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
       artefact["details"].merge!(
-        "need_id" => "42",
+        "need_ids" => [100001, 100002],
         "business_proposition" => true
       )
       headers = {


### PR DESCRIPTION
with this [story](https://www.pivotaltracker.com/story/show/67206140) it is possible to associate multiple
need ids to an artefact. so making sure all of those get
passed onto Google Analytics and Performance tracking.

the Google Analytics team has specifically requested us
to not change the NeedId custom var name, to not have
to port existing reports.

will be removing the NeedId header next, and then release.
