### PR TITLE
Removing unused need_id header

### DIFF
--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -9,7 +9,6 @@ module Slimmer
       beta:                 "Beta",
       beta_label:           "Beta-Label",
       format:               "Format",
-      need_id:              "Need-ID",
       page_owner:           "Page-Owner",
       proposition:          "Proposition",
       organisations:        "Organisations",

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -14,11 +14,6 @@ class HeadersTest < MiniTest::Unit::TestCase
     assert_equal "rhubarb", headers["X-Slimmer-Section"]
   end
 
-  def test_should_set_need_id_header
-    set_slimmer_headers need_id: "rhubarb"
-    assert_equal "rhubarb", headers["X-Slimmer-Need-ID"]
-  end
-
   def test_should_set_format_header
     set_slimmer_headers format: "rhubarb"
     assert_equal "rhubarb", headers["X-Slimmer-Format"]


### PR DESCRIPTION
couldn't find a reference to it from any app.
assuming that we're only setting it from the
artefact's need_ids field.
