### PR TITLE
Nil check for multivalue custom vars

### DIFF
--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -33,7 +33,7 @@ module Slimmer::Processors
     end
 
     def set_multivalue_custom_var(slot, name, values)
-      return nil if values.empty?
+      return nil if !values.is_a?(Array) || values.empty?
       set_custom_var(slot, name, values.join(',').downcase)
     end
 

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -119,6 +119,28 @@ module GoogleAnalyticsTest
     end
   end
 
+  class WithInvalidAttributes < SlimmerIntegrationTest
+    include JavaScriptAssertions
+
+    def setup
+      super
+    end
+
+    def test_should_skip_passing_need_ids_if_they_are_nil
+      artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
+      headers = {
+        Slimmer::Headers::ARTEFACT_HEADER => artefact.to_json,
+        Slimmer::Headers::FORMAT_HEADER => "custard"
+      }
+      given_response 200, GENERIC_DOCUMENT, headers
+
+      refute_custom_var "NeedID"
+      # the presence of these attributes tests that the nil check worked
+      assert_custom_var 1, "Section", "rhubarb", PAGE_LEVEL_EVENT
+      assert_custom_var 2, "Format", "custard", PAGE_LEVEL_EVENT
+    end
+  end
+
   class WithoutHeadersTest < SlimmerIntegrationTest
     include JavaScriptAssertions
 


### PR DESCRIPTION
if the multivalue custom var was nil the processor would crash and GA variables went missing from the page.
