### PR TITLE
Remove use of FACTER_govuk_platform

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,8 +8,6 @@ require 'mocha'
 require 'timecop'
 require 'gds_api/test_helpers/content_api'
 
-ENV['FACTER_govuk_platform'] = 'test'
-
 class MiniTest::Unit::TestCase
   def as_nokogiri(html_string)
     Nokogiri::HTML.parse(html_string.strip)


### PR DESCRIPTION
This variable is being removed from puppet. It's actually set to the same
thing as Rails.env, so Rails.env can be substituted wherever it is used.

It was placed here in
https://github.com/alphagov/slimmer/commit/139c44dced286d8c9beae6696624eacd935afef2

Removing it does not cause the tests to fail, so I don't see it being
necessary. It's not used in the code.
