### PR TITLE
Include rack_env when notifying exceptions

### DIFF
--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -90,9 +90,9 @@ module Slimmer
       when 200
         @skin.success request, response, s(response.body)
       when 404
-        @skin.error '404', s(response.body)
+        @skin.error '404', s(response.body), request.env
       else
-        @skin.error '500', s(response.body)
+        @skin.error '500', s(response.body), request.env
       end
 
       rewritten_body = [rewritten_body] unless rewritten_body.respond_to?(:each)


### PR DESCRIPTION
We are seeing a number of exception notifications in whitehall that are devoid of any environment information, including the request that caused it (e.g. https://errbit.production.alphagov.co.uk/apps/53020d6c0da11585f10000e7/problems/537cbab40da11556e500325a), making it impossible to identify the cause of the problem. This has been traced back to the exception handling here in slimmer, which notifies on exceptions in processors, but without including the Rack environment. This change will mean the rack environment is passed through to Airbrake such that it will be included in the notification that gets generated.
