### PR TITLE
Use production assets in test mode

### DIFF
--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -16,8 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/header-footer-only.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/header-footer-only.js" type="text/javascript"></script>
   </body>
 </html>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -16,8 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script src="https://assets-origin.preview.alphagov.co.uk/static/application.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets.digital.cabinet-office.gov.uk/static/application.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
Since preview was moved to its new home, we've seen a noticable drop in performance. We suspect the slow loading of assets is what is causing the sporadic failing of JS-enabled capybara scenarios on CI. This
updates the test templates to load assets from production instead of preview.

The longer-term fix will be to get an instance of static running on CI and load static assets directly from the local instance.
