### PR TITLE
Safer branch builds

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,8 +1,15 @@
 #!/bin/bash -x
 set -e
+
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
 rm -f Gemfile.lock
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake test --trace
+
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem --trace
 fi


### PR DESCRIPTION
- Don't attempt to publish new gem versions for branches (matching ENV added to Jenkins job)
- Attempt to merge against master before running tests, as per recent Whitehall and Rummager changes
