### PR TITLE
Upgrade some test dependencies.

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -26,10 +26,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport'
 
   s.test_files    = Dir['test/**/*']
+  s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rack-test', '~> 0.6.1'
-  s.add_development_dependency 'mocha', '~> 0.12.4'
-  s.add_development_dependency 'webmock', '1.11.0'
+  s.add_development_dependency 'mocha', '~> 1.1'
+  s.add_development_dependency 'webmock', '1.18.0'
   s.add_development_dependency 'therubyracer', '~> 0.10.2'
   s.add_development_dependency 'gem_publisher', '~> 1.1.1'
   s.add_development_dependency 'gds-api-adapters', '2.7.1'

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "slimmer/headers"
 
-class HeadersTest < MiniTest::Unit::TestCase
+class HeadersTest < MiniTest::Test
   include Slimmer::Headers
   attr_accessor :headers
 

--- a/test/processors/alpha_label_inserter_test.rb
+++ b/test/processors/alpha_label_inserter_test.rb
@@ -1,6 +1,6 @@
 require_relative "../test_helper"
 
-class AlphaLabelInserterTest < MiniTest::Unit::TestCase
+class AlphaLabelInserterTest < MiniTest::Test
 
   def setup
     super

--- a/test/processors/beta_label_inserter_test.rb
+++ b/test/processors/beta_label_inserter_test.rb
@@ -1,6 +1,6 @@
 require_relative "../test_helper"
 
-class BetaLabelInserterTest < MiniTest::Unit::TestCase
+class BetaLabelInserterTest < MiniTest::Test
 
   def setup
     super

--- a/test/processors/body_inserter_test.rb
+++ b/test/processors/body_inserter_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class BodyInserterTest < MiniTest::Unit::TestCase
+class BodyInserterTest < MiniTest::Test
   def test_should_replace_contents_of_wrapper_in_template
     template = as_nokogiri %{
       <html><body><div><div id="wrapper"></div></div></body></html>

--- a/test/processors/header_context_inserter_test.rb
+++ b/test/processors/header_context_inserter_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class HeaderContextInserterTest < MiniTest::Unit::TestCase
+class HeaderContextInserterTest < MiniTest::Test
   def test_should_replace_contents_of_header_context_in_template
     template = as_nokogiri %{
       <html><body><div><div class="header-context"></div></div></body></html>

--- a/test/processors/navigation_mover_test.rb
+++ b/test/processors/navigation_mover_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-class NavigationMoverTest < MiniTest::Unit::TestCase
+class NavigationMoverTest < MiniTest::Test
   def setup
     super
     @proposition_header_block = File.read( File.dirname(__FILE__) + "/../fixtures/proposition_menu.html.erb" )

--- a/test/processors/related_items_inserter_test.rb
+++ b/test/processors/related_items_inserter_test.rb
@@ -1,7 +1,7 @@
 require_relative '../test_helper'
 require 'gds_api/test_helpers/content_api'
 
-class RelatedItemsInserterTest < MiniTest::Unit::TestCase
+class RelatedItemsInserterTest < MiniTest::Test
   include GdsApi::TestHelpers::ContentApi
 
   def setup

--- a/test/processors/report_a_problem_inserter_test.rb
+++ b/test/processors/report_a_problem_inserter_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-class ReportAProblemInserterTest < MiniTest::Unit::TestCase
+class ReportAProblemInserterTest < MiniTest::Test
 
   def setup
     super

--- a/test/processors/section_inserter_test.rb
+++ b/test/processors/section_inserter_test.rb
@@ -1,7 +1,7 @@
 require_relative "../test_helper"
 require 'gds_api/test_helpers/content_api'
 
-class SectionInserterTest < MiniTest::Unit::TestCase
+class SectionInserterTest < MiniTest::Test
   include GdsApi::TestHelpers::ContentApi
 
   def create_artefact(slug, attributes = {})

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -1,6 +1,6 @@
 require_relative "../test_helper"
 
-class TagMoverTest < MiniTest::Unit::TestCase
+class TagMoverTest < MiniTest::Test
   def setup
     super
     @source = as_nokogiri %{

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,14 +1,13 @@
 require_relative '../lib/slimmer'
 require 'minitest/autorun'
-require 'minitest/unit'
 require 'rack/test'
 require 'json'
 require 'logger'
-require 'mocha'
+require 'mocha/setup'
 require 'timecop'
 require 'gds_api/test_helpers/content_api'
 
-class MiniTest::Unit::TestCase
+MiniTest::Test.class_eval do
   def as_nokogiri(html_string)
     Nokogiri::HTML.parse(html_string.strip)
   end
@@ -59,7 +58,7 @@ module ActionView
   end
 end
 
-class SlimmerIntegrationTest < MiniTest::Unit::TestCase
+class SlimmerIntegrationTest < MiniTest::Test
   include Rack::Test::Methods
   include GdsApi::TestHelpers::ContentApi
 

--- a/test/test_template_dependency_on_static_test.rb
+++ b/test/test_template_dependency_on_static_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class TestTemplateDependencyOnStaticTest < MiniTest::Unit::TestCase
+class TestTemplateDependencyOnStaticTest < MiniTest::Test
   def test_scripts_on_static_referenced_in_test_templates_exist
     template_path = File.dirname(__FILE__).gsub('/test', '/lib/slimmer/test_templates')
     Dir.foreach(template_path) do | template_file_name |

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -153,7 +153,7 @@ module TypicalUsage
     }
     def test_should_find_conditional_comments_copied_into_the_head
       element = Nokogiri::HTML.parse(last_response.body).at_xpath('//comment()')
-      assert_match element.to_s, /app-ie\.css/, 'Not found conditional comment in output'
+      assert_match /app-ie\.css/, element.to_s, 'Not found conditional comment in output'
     end
   end
 
@@ -168,7 +168,7 @@ module TypicalUsage
     def test_should_find_stylesheet_wrapped_with_conditional_comments
       assert_rendered_in_template "head link[href='app.css']"
       element = Nokogiri::HTML.parse(last_response.body).at_xpath('/html/head')
-      assert_match element.to_s, /<!--\[if gt IE 8\]><!-->.*app\.css.*<!--<!\[endif\]-->/m, 'Not found conditional comment in output'
+      assert_match /<!--\[if gt IE 8\]><!-->.*app\.css.*<!--<!\[endif\]-->/m, element.to_s, 'Not found conditional comment in output'
     end
   end
 


### PR DESCRIPTION
Solution to the problem described in #81.  Upgrading mocha resolved the
issue with it breaking for newer versions of activesupport.  This in
turn pulled in newer versions of minitest, which in turn required a
newer version of webmock.
