### PR TITLE
Extract cache into its class

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -17,6 +17,8 @@ module Slimmer
   autoload :Railtie, 'slimmer/railtie'
   autoload :Skin, 'slimmer/skin'
 
+  autoload :Cache, 'slimmer/cache'
+
   autoload :Template, 'slimmer/template'
   autoload :App, 'slimmer/app'
   autoload :Headers, 'slimmer/headers'

--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -28,7 +28,10 @@ module Slimmer
         options[:asset_host] = Plek.current.find("static")
       end
 
-      @skin = Skin.new options.merge(logger: self.logger)
+      cache = Cache.instance
+      cache.use_cache = options[:use_cache] if options[:use_cache]
+
+      @skin = Skin.new options.merge(logger: self.logger, cache: cache)
     end
 
     def call(env)

--- a/lib/slimmer/cache.rb
+++ b/lib/slimmer/cache.rb
@@ -1,0 +1,46 @@
+require 'singleton'
+
+module Slimmer
+  class Cache
+    include Singleton
+    attr_writer :use_cache, :cache_ttl
+
+    # TODO: use a real cache rather than an in memory hash
+    def initialize
+      @cache_last_reset= Time.now
+
+      @use_cache = false
+      @cache_ttl = (5 * 60) # 5 mins
+
+      @data_store = {}
+    end
+
+    def clear
+      @data_store.clear
+    end
+
+    def fetch(key)
+      clear_cache_if_stale
+      data = @data_store[key]
+
+      if data.nil?
+        data = yield
+      end
+
+      if @use_cache
+        @data_store[key] = data
+      end
+
+      data
+    end
+
+  private
+    def clear_cache_if_stale
+      time_to_clear_cache = @cache_last_reset + @cache_ttl
+      if time_to_clear_cache < Time.now
+        @data_store.clear
+        @cache_last_reset = Time.now
+      end
+    end
+  end
+end

--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -3,14 +3,23 @@ require 'active_support/core_ext/string/inflections'
 
 module Slimmer
   class ComponentResolver < ::ActionView::Resolver
+    def self.caching
+      # this turns off the default ActionView::Resolver caching which caches
+      # all templates for the duration of the current process in production
+      false
+    end
+
     def find_templates(name, prefix, partial, details)
       return [] unless prefix == 'govuk_component'
+      cache = Cache.instance
 
       template_path = [prefix, name].join('/')
       if test?
         template_body = test_body(template_path)
       else
-        template_body = fetch(template_url(template_path))
+        template_body = cache.fetch(template_path) do
+          fetch(template_url(template_path))
+        end
       end
 
       details = {

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -3,28 +3,19 @@ require 'slimmer/govuk_request_id'
 
 module Slimmer
   class Skin
-    attr_accessor :use_cache, :template_cache, :asset_host, :logger, :strict, :options
+    attr_accessor :template_cache, :asset_host, :logger, :strict, :options
 
-    # TODO: Extract the cache to something we can pass in instead of using
-    # true/false and an in-memory cache.
     def initialize options = {}
       @options = options
       @asset_host = options[:asset_host]
-
-      @use_cache = options[:use_cache] || false
-      @cache_ttl = options[:cache_ttl] || (15 * 60) # 15 mins
-      @template_cache = LRUCache.new(:ttl => @cache_ttl) if @use_cache
+      @template_cache = options[:cache]
 
       @logger = options[:logger] || NullLogger.instance
       @strict = options[:strict] || (%w{development test}.include?(ENV['RACK_ENV']))
     end
 
     def template(template_name)
-      if use_cache
-        template_cache.fetch(template_name) do
-          load_template(template_name)
-        end
-      else
+      template_cache.fetch(template_name) do
         load_template(template_name)
       end
     end

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'plek', '>= 0.1.8'
   s.add_dependency 'json'
   s.add_dependency 'null_logger'
-  s.add_dependency 'lrucache', '~> 0.1.3'
   s.add_dependency 'rest-client'
   s.add_dependency 'activesupport'
 

--- a/test/cache_test.rb
+++ b/test/cache_test.rb
@@ -1,0 +1,53 @@
+require_relative "test_helper"
+
+describe Slimmer::Cache do
+  describe "a cache" do
+    before do
+      @cache = Slimmer::Cache.send(:new)
+      @cache.use_cache = false
+    end
+
+    it "should not save item in cache by default" do
+      @cache.fetch('not-cached') { "value1" }
+      assert_equal 'new-value', @cache.fetch('not-cached') { "new-value" }
+    end
+
+    it "should return passed argument if cache is empty" do
+      @cache.use_cache = true
+
+      assert_equal 'new-value', @cache.fetch('uncached-key') { "new-value" }
+    end
+
+    it "should return cached argument if cache is enabled and warm" do
+      @cache.use_cache = true
+
+      @cache.fetch('cached-key') { "value1" }
+      assert_equal 'value1', @cache.fetch('cached-key') { "new-value" }
+    end
+
+    it "should only cache the template for 5 mins by default" do
+      @cache.use_cache = true
+
+      @cache.fetch('timed-cached-key') { "value1" }
+      Timecop.travel( 5 * 60 - 30) do # now + 4 mins 30 secs
+        assert_equal "value1", @cache.fetch('timed-cached-key') { "value2" }
+      end
+      Timecop.travel( 5 * 60 + 30) do # now + 5 mins 30 secs
+        assert_equal "value3", @cache.fetch('timed-cached-key') { "value3" }
+      end
+    end
+
+    it "should allow overriding the cache ttl" do
+      @cache.use_cache = true
+      @cache.cache_ttl = 10 * 60
+
+      @cache.fetch('ttl-timed-cached-key') { "value1" }
+      Timecop.travel( 10 * 60 - 30) do # now + 9 mins 30 secs
+        assert_equal "value1", @cache.fetch('ttl-timed-cached-key') { "value2" }
+      end
+      Timecop.travel( 10 * 60 + 30) do # now + 10 mins 30 secs
+        assert_equal "value3", @cache.fetch('ttl-timed-cached-key') { "value3" }
+      end
+    end
+  end
+end

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -4,7 +4,8 @@ describe Slimmer::Skin do
 
   describe "loading templates" do
     it "should be able to load the template" do
-      skin = Slimmer::Skin.new asset_host: "http://example.local/"
+      skin = Slimmer::Skin.new asset_host: "http://example.local/", cache: Slimmer::Cache.instance
+
       expected_url = "http://example.local/templates/example.html.erb"
       stub_request(:get, expected_url).to_return :body => "<foo />"
 
@@ -16,7 +17,8 @@ describe Slimmer::Skin do
 
     describe "should pass the GOVUK-Request-Id header when requesting the template" do
       before do
-        @skin = Slimmer::Skin.new asset_host: "http://example.local/"
+        @skin = Slimmer::Skin.new asset_host: "http://example.local/", cache: Slimmer::Cache.instance
+
         @expected_url = "http://example.local/templates/example.html.erb"
         stub_request(:get, @expected_url).to_return :body => "<foo />"
       end
@@ -42,81 +44,17 @@ describe Slimmer::Skin do
       end
     end
 
-    describe "template caching" do
-      it "should not cache the template by default" do
-        skin = Slimmer::Skin.new asset_host: "http://example.local/"
-        expected_url = "http://example.local/templates/example.html.erb"
-        stub_request(:get, expected_url).to_return :body => "<foo />"
+    it "should try and load templates from the cache" do
+      skin = Slimmer::Skin.new asset_host: "http://example.local/", cache: Slimmer::Cache.instance
 
-        first_access = skin.template 'example'
-        second_access = skin.template 'example'
-
-        assert_requested :get, "http://example.local/templates/example.html.erb", times: 2
-      end
-
-      it "should cache the template when requested" do
-        skin = Slimmer::Skin.new asset_host: "http://example.local/", use_cache: true
-        expected_url = "http://example.local/templates/example.html.erb"
-        stub_request(:get, expected_url).to_return :body => "<foo />"
-
-        first_access = skin.template 'example'
-        second_access = skin.template 'example'
-
-        assert_requested :get, "http://example.local/templates/example.html.erb", times: 1
-        assert_same first_access, second_access
-      end
-
-      it "should only cache the template for 15 mins by default" do
-        skin = Slimmer::Skin.new asset_host: "http://example.local/", use_cache: true
-        expected_url = "http://example.local/templates/example.html.erb"
-        stub_request(:get, expected_url).to_return :body => "<foo />"
-
-        first_access = skin.template 'example'
-        second_access = skin.template 'example'
-
-        assert_requested :get, "http://example.local/templates/example.html.erb", times: 1
-        assert_same first_access, second_access
-
-        Timecop.travel( 15 * 60 - 30) do # now + 14 mins 30 secs
-          third_access = skin.template 'example'
-          assert_requested :get, "http://example.local/templates/example.html.erb", times: 1
-          assert_same first_access, third_access
-        end
-
-        Timecop.travel( 15 * 60 + 30) do # now + 15 mins 30 secs
-          fourth_access = skin.template 'example'
-          assert_requested :get, "http://example.local/templates/example.html.erb", times: 2
-          assert_equal first_access, fourth_access
-        end
-      end
-
-      it "should allow overriding the cache ttl" do
-        skin = Slimmer::Skin.new asset_host: "http://example.local/", use_cache: true, cache_ttl: 5 * 60
-        expected_url = "http://example.local/templates/example.html.erb"
-        stub_request(:get, expected_url).to_return :body => "<foo />"
-
-        first_access = skin.template 'example'
-        second_access = skin.template 'example'
-
-        assert_requested :get, "http://example.local/templates/example.html.erb", times: 1
-        assert_same first_access, second_access
-
-        Timecop.travel( 5 * 60 - 30) do # now + 4 mins 30 secs
-          third_access = skin.template 'example'
-          assert_requested :get, "http://example.local/templates/example.html.erb", times: 1
-          assert_same first_access, third_access
-        end
-
-        Timecop.travel( 5 * 60 + 30) do # now + 5 mins 30 secs
-          fourth_access = skin.template 'example'
-          assert_requested :get, "http://example.local/templates/example.html.erb", times: 2
-          assert_equal first_access, fourth_access
-        end
-      end
+      Slimmer::Cache.instance.expects(:fetch).with('example-template').returns('cache data')
+      template = skin.template 'example-template'
+      assert_equal 'cache data', template
     end
 
     it "should raise appropriate exception when template not found" do
-      skin = Slimmer::Skin.new asset_host: "http://example.local/"
+      skin = Slimmer::Skin.new asset_host: "http://example.local/", cache: Slimmer::Cache.instance
+
       expected_url = "http://example.local/templates/example.html.erb"
       stub_request(:get, expected_url).to_return(:status => '404')
 
@@ -126,7 +64,8 @@ describe Slimmer::Skin do
     end
 
     it "should raise appropriate exception when cant reach template host" do
-      skin = Slimmer::Skin.new asset_host: "http://example.local/"
+      skin = Slimmer::Skin.new asset_host: "http://example.local/", cache: Slimmer::Cache.instance
+
       expected_url = "http://example.local/templates/example.html.erb"
       stub_request(:get, expected_url).to_raise(Errno::ECONNREFUSED)
 
@@ -136,7 +75,8 @@ describe Slimmer::Skin do
     end
 
     it "should raise appropriate exception when hostname cannot be resolved" do
-      skin = Slimmer::Skin.new asset_host: "http://non-existent.domain/"
+      skin = Slimmer::Skin.new asset_host: "http://non-existent.domain/", cache: Slimmer::Cache.instance
+
       expected_url = "http://non-existent.domain/templates/example.html.erb"
       stub_request(:get, expected_url).to_raise(SocketError)
 
@@ -148,7 +88,7 @@ describe Slimmer::Skin do
 
   describe "parsing artefact from header" do
     before do
-      @skin = Slimmer::Skin.new
+      @skin = Slimmer::Skin.new cache: Slimmer::Cache.instance
       @headers = {}
       @response = stub("Response", :headers => @headers)
     end


### PR DESCRIPTION
Create an in memory cache class which will expunge the whole cache after
the ttl in one go.

Pass this cache into the skin method.

Use this cache for the shared template resolver and turn off the default
caching in that resolver.

This means that the main template and all component templates will
always remain in sync so that the main skin template can provide the
stylesheets for the components and they won't become out of sync with
each other.

Ideally in the future the cache can be further abstracted out to a
proper caching server.

Also reduce the cache time to 5 minutes so templates are updated faster.
