### PR TITLE
Remove lrucache include

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -7,7 +7,6 @@ require 'nokogiri'
 require 'erb'
 require 'plek'
 require 'null_logger'
-require 'lrucache'
 
 require 'slimmer/version'
 require 'slimmer/railtie' if defined? Rails


### PR DESCRIPTION
The dependency on it was removed in d0a963c8 but it was left in as an
include.
