### PR TITLE
Add a Search-Parameters header

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -43,6 +43,7 @@ module Slimmer
     autoload :ReportAProblemInserter, 'slimmer/processors/report_a_problem_inserter'
     autoload :SearchIndexSetter, 'slimmer/processors/search_index_setter'
     autoload :SearchPathSetter, 'slimmer/processors/search_path_setter'
+    autoload :SearchParameterInserter, 'slimmer/processors/search_parameter_inserter'
     autoload :SectionInserter, 'slimmer/processors/section_inserter'
     autoload :TagMover, 'slimmer/processors/tag_mover'
     autoload :TitleInserter, 'slimmer/processors/title_inserter'

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -16,6 +16,7 @@ module Slimmer
       world_locations:      "World-Locations",
       remove_meta_viewport: "Remove-Meta-Viewport",
       result_count:         "Result-Count",
+      search_parameters:    "Search-Parameters",
       section:              "Section",
       skip:                 "Skip",
       template:             "Template",
@@ -33,6 +34,7 @@ module Slimmer
     REMOVE_META_VIEWPORT = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_meta_viewport]}"
     RESULT_COUNT_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:result_count]}"
     SEARCH_PATH_HEADER = "#{HEADER_PREFIX}-Search-Path"
+    SEARCH_PARAMETERS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:search_parameters]}"
     SKIP_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:skip]}"
     TEMPLATE_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:template]}"
 

--- a/lib/slimmer/processors/search_parameter_inserter.rb
+++ b/lib/slimmer/processors/search_parameter_inserter.rb
@@ -1,0 +1,50 @@
+require 'json'
+
+module Slimmer::Processors
+  class SearchParameterInserter
+    def initialize(response)
+      @response = response
+    end
+
+    def filter(content_document, page_template)
+      search_form = page_template.at_css('form#search')
+      if search_parameters && search_form
+        search_parameters.each_pair do |name, value|
+          # Value can either be a string or an array of values
+          if value.is_a? Array
+            array_name = "#{name}[]"
+            value.each do |array_value|
+              add_hidden_input(search_form, array_name, array_value)
+            end
+          else
+            add_hidden_input(search_form, name, value)
+          end
+        end
+      end
+    end
+
+    def add_hidden_input(search_form, name, value)
+      element = Nokogiri::XML::Node.new('input', search_form)
+      element['type'] = 'hidden'
+      element['name'] = name
+      element['value'] = value.to_s
+      search_form.add_child(element)
+    end
+
+    def search_parameters
+      @search_parameters ||= parse_search_parameters
+    end
+
+    def parse_search_parameters
+      header_value = @response.headers.fetch(Slimmer::Headers::SEARCH_PARAMETERS_HEADER)
+      if header_value.nil?
+        []
+      else
+        JSON.parse(header_value)
+      end
+    rescue JSON::ParserError => e
+      logger.error "Slimmer: Failed while parsing search parameters header: #{[ e.message, e.backtrace ].flatten.join("\n")}"
+      []
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -116,6 +116,7 @@ module Slimmer
         Processors::HeaderContextInserter.new(),
         Processors::SectionInserter.new(artefact),
         Processors::GoogleAnalyticsConfigurator.new(response, artefact),
+        Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
         Processors::RelatedItemsInserter.new(self, artefact),
         Processors::LogoClassInserter.new(artefact),

--- a/test/processors/search_parameter_inserter_test.rb
+++ b/test/processors/search_parameter_inserter_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+module SearchParameterInserterTest
+
+  DOCUMENT_WITH_SEARCH = <<-END
+    <html>
+      <head>
+      </head>
+      <body class="body_class">
+        <div id="wrapper">
+          <form id="search" action="/path/to/search">
+          </form>
+        </div>
+      </body>
+    </html>
+  END
+
+  class WithHeaderTest < SlimmerIntegrationTest
+    headers = {
+      "X-Slimmer-Search-Parameters" => '{"filter_organisations": ["land-registry"], "count": 20}',
+    }
+
+    given_response 200, DOCUMENT_WITH_SEARCH, headers
+
+    def test_should_add_hidden_input
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).css('#search input[type=hidden]')
+      assert_equal %{<input type="hidden" name="filter_organisations[]" value="land-registry"><input type="hidden" name="count" value="20">}, hidden_inputs.to_s
+    end
+  end
+
+  class WithInvalidHeaderTest < SlimmerIntegrationTest
+    headers = {
+      "X-Slimmer-Search-Parameters" => '[not-valid-json',
+    }
+
+    given_response 200, DOCUMENT_WITH_SEARCH, headers
+
+    def test_should_not_add_hidden_input
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
+      assert_equal nil, hidden_inputs
+    end
+  end
+
+  class WithoutHeaderTest < SlimmerIntegrationTest
+    given_response 200, DOCUMENT_WITH_SEARCH, {}
+
+    def test_should_leave_original_search_action
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
+      assert_equal nil, hidden_inputs
+    end
+  end
+end


### PR DESCRIPTION
This allows apps to add extra parameters, which will be submitted along
with any search entry made from the page.  They get transformed into
hidden input elements in the search form.

This is part of https://www.pivotaltracker.com/story/show/77617490 -
there'll be a follow-up PR on whitehall which emits a header value to
filter search results by organisation for some pages.
