### PR TITLE
Handle missing search parameters header

### DIFF
--- a/lib/slimmer/processors/search_parameter_inserter.rb
+++ b/lib/slimmer/processors/search_parameter_inserter.rb
@@ -36,7 +36,7 @@ module Slimmer::Processors
     end
 
     def parse_search_parameters
-      header_value = @response.headers.fetch(Slimmer::Headers::SEARCH_PARAMETERS_HEADER)
+      header_value = @response.headers.fetch(Slimmer::Headers::SEARCH_PARAMETERS_HEADER, nil)
       if header_value.nil?
         []
       else


### PR DESCRIPTION
Previously, a missing header would have caused an exception.  Slimmer
would have then handled the exception, so the page would have worked,
but reports would have been sent to errbit.

I believe this will fix the problem, but I can't see an easy way to add a test for this, because slimmer catches any exceptions in processors.  Advice welcome (though less welcome if it says "add a whole new unit testing framework to slimmer").
