### PR TITLE
Bump version to 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.3.1
+
+* When running tests, don't hide exceptions in the processors. Fix a bug in the
+  Search-Parameters processor's handling of missing headers revealed by this.
+
 # 4.3.0
 
 * Add a Search-Parameters header, to allow apps to add extra parameters to

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '4.3.0'
+  VERSION = '4.3.1'
 end


### PR DESCRIPTION
This includes the changes from
https://github.com/alphagov/slimmer/pull/92

When running tests, don't hide exceptions in the processors. Fix a bug
in the Search-Parameters processor's handling of missing headers
revealed by this.
