### PR TITLE
Bump version to 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+# 5.0.0
+
+This release contains breaking changes.
+
+* The report-a-problem form is now zero-configuration; it's no longer necessary
+  to add a `div class="report-a-problem"` or extra styling to the app. Slimmer
+  appends the form to the `wrapper` div by default (the default CSS selector for
+  the wrapper div is `#wrapper`, but this id can be overwritten by defining
+  `config.slimmer.wrapper_id` in the app's `application.rb`).
+
+* The report-a-problem form is now opt-out; it's added by default, but can be
+  skipped by setting the `Slimmer::Headers::REPORT_A_PROBLEM_FORM` header value
+  to `false`.
+
+* The steps for upgrading an app that already has report-a-problem are:
+
+  1. Remove all `div class="report-a-problem"` from the app
+  2. Remove all CSS relating to `report-a-problem` or `report-a-problem-toggle`
+  3. Set `Slimmer::Headers::REPORT_A_PROBLEM_FORM` to `false` for any controllers
+  or actions where you don't want the form to appear.
+
 # 4.3.1
 
 * When running tests, don't hide exceptions in the processors. Fix a bug in the

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '4.3.1'
+  VERSION = '5.0.0'
 end


### PR DESCRIPTION
This includes https://github.com/alphagov/slimmer/pull/85:
making the report-a-problem form self-contained and opt-out
