### PR TITLE
Fix specified version of Plek

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'nokogiri', '~> 1.5.0'
   s.add_dependency 'rack', '>= 1.3.5'
-  s.add_dependency 'plek', '>= 0.1.8'
+  s.add_dependency 'plek', '>= 1.1.0'
   s.add_dependency 'json'
   s.add_dependency 'null_logger'
   s.add_dependency 'rest-client'


### PR DESCRIPTION
The version of Plek specified as the minimum requires an argument to be passed
to Plek.new, but we call it in component_resolver.rb without an argument.

Passing an argument was made optional in Plek 1.0.0, but 1.0.0 requires an
environment variable to be set. 1.1.0 and above don't, so lets specify that.
