### PR TITLE
Support 410 responses

### DIFF
--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -94,6 +94,8 @@ module Slimmer
         @skin.success request, response, s(response.body)
       when 404
         @skin.error '404', s(response.body), request.env
+      when 410
+        @skin.error '410', s(response.body), request.env
       else
         @skin.error '500', s(response.body), request.env
       end

--- a/test/fixtures/410.html.erb
+++ b/test/fixtures/410.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Slimmer, yay!</title>
+  </head>
+  <body>
+    <div class="content">
+      <header><h1>That's gone now, sorry.</h1></header>
+      <div id="wrapper" class="group">
+      </div>
+    </div>
+  </body>
+</html>

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,7 @@ class SlimmerIntegrationTest < MiniTest::Test
     template_name = case code
     when 200 then 'wrapper'
     when 404 then '404'
+    when 410 then '410'
     else          '500'
     end
 

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -370,6 +370,33 @@ module TypicalUsage
     end
   end
 
+  class Error410ResponseTest < SlimmerIntegrationTest
+    given_response 410, %{
+      <html>
+      <head><title>410 Gone</title>
+      <meta name="something" content="yes">
+      <script src="blah.js"></script>
+      <link href="app.css" rel="stylesheet" type="text/css">
+      </head>
+      <body class="body_class">
+      <div id="wrapper"><p class='message'>Something bad happened</p></div>
+      </body>
+      </html>
+    }
+
+    def test_should_not_replace_the_wrapper_using_the_app_response
+      assert_not_rendered_in_template "Something bad happened"
+    end
+
+    def test_should_include_default_410_error_message
+      assert_rendered_in_template "body .content header h1", "That's gone now, sorry."
+    end
+
+    def test_should_replace_the_title_using_the_app_response
+      assert_rendered_in_template "head title", "410 Gone"
+    end
+  end
+
   class ArbitraryWrapperIdTest < SlimmerIntegrationTest
 
     given_response 200, %{


### PR DESCRIPTION
At the moment, if an app using slimmer returns a 410 response, the status code
is preserved, but the body is rewritten to the generic 500 error page.

Whilst I believe pages which have been removed from GOV.UK should be registered as such
with the Router, if an app returns a 410, it should be honoured. Additionally, if Slimmer is reused without the Router by third parties, then responses should not be rewritten to look like server errors.

Static already has a 410 template, so this should "just work". I tested it successfully in development.
