### PR TITLE
First iteration of network based i18n translations

### DIFF
--- a/lib/slimmer/component_i18n_backend.rb
+++ b/lib/slimmer/component_i18n_backend.rb
@@ -1,12 +1,12 @@
 require 'json'
 
 module Slimmer
-  class ComponentI18nBackend
+  class I18nBackend
     include I18n::Backend::Base, I18n::Backend::Flatten
 
     def available_locales
       cache.fetch("available_locales") do
-        locale_json = fetch(static_component_url("translations"))
+        locale_json = fetch(static_locales_url)
         locales = JSON.parse(locale_json).map(&:to_sym)
       end
     end
@@ -29,8 +29,8 @@ module Slimmer
       end
     end
 
-    def static_component_url(file)
-      [static_host, "templates", "govuk_component", file].compact.join('/')
+    def static_locales_url(locale=nil)
+      [static_host, "templates", "locales", locale].compact.join('/')
     end
 
     def static_host
@@ -38,7 +38,7 @@ module Slimmer
     end
 
     def fetch_translations(locale)
-      url = static_component_url("translations/#{locale}")
+      url = static_locales_url(locale)
       json_data = fetch(url)
       translations = JSON.parse(json_data)
       flatten_translations(locale, translations, false, false)


### PR DESCRIPTION
To enable us to have components which have translated strings in them. 
For example the titles on the metadata component. 

This doesn't necessarily want merging in this state but I would appreciate
comments and thoughts on the approach and direction.

---

A i18n backend which can be plugged into Rails. This will let us load
translations for strings which are in components dynamically the same
way we are loading templates. This means we can then reliably update
translations for components across the site.

As this uses the same caching engine as the component loader the
translation calls and the translations should always remain in sync.

This will need some changes to Static to serve JSON translation files.
The files which will need to be served are:

```
/templates/govuk_component/translations
```

This should be a JSON array of different locales which are available.
For each locale that is available there should be a JSON representation
of the YAML file you would normally find in ./config/locales/:locale.yml:

```
/templates/govuk_component/translations/:locale
```

Where `:locale` is a two letter language code.

The I18n backend can be added to the default Simple backend in rails by
calling:

``` ruby
I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::ComponentI18nBackend.new)
```

This will cause Rails to first try and use the strings from the
application and then fallback onto this backend. This will also enable
applications to override strings if they need to be different for some
reason.

In a component you could then call something like:

``` erb
<dt><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
```
