### PR TITLE
Return a JSON blob in tests using components

### DIFF
--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -62,7 +62,7 @@ module Slimmer
     end
 
     def test_body(path)
-      %Q{<div class="#{path.parameterize}"><%= local_assigns.keys.join(' ') %></div>}
+      %Q{<script type="text/component-source" class="#{path.parameterize}"><%= JSON.dump(local_assigns) %></script>}
     end
   end
 end

--- a/test/component_resolver_test.rb
+++ b/test/component_resolver_test.rb
@@ -23,7 +23,7 @@ describe Slimmer::ComponentResolver do
       @resolver.expects(:test?).returns(true)
 
       templates = @resolver.find_templates('name', 'govuk_component', false, {})
-      assert_match /<div class="govuk_component-name">/, templates.first.args[0]
+      assert_match /<script type="text\/component-source" class="govuk_component-name">/, templates.first.args[0]
     end
   end
 end


### PR DESCRIPTION
Instead of returning a list of keys, the component resolver now returns a JSON blob of all the locals and their values in tests.
