### PR TITLE
Bump to 5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 5.1.0
+
+* `ComponentResolver#test_body` returns a JSON blob of the components keys and values instead of just the values.
+
+* Add an I18n backend to load translations over the network from static
+
 # 5.0.1
 
 * Fix MetaViewportRemover to not raise an exception if there is no meta

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '5.0.1'
+  VERSION = '5.1.0'
 end


### PR DESCRIPTION
This bump contains the following changes:
- `ComponentResolver#test_body` returns a JSON blob of the components keys and values instead of just the values.
- Add an I18n backend to load translations over the network from static
