### PR TITLE
Release 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 6.0.0
+
+* Change ComponentResolver to use a bespoke tag - `test-govuk-component` - when
+  running in a test, rather than `script`. Use `data-template` rather than
+  `class` to identify which template was used.
+* Fix bug where Slimmer::TestHelpers::SharedTemplates#shared_component_selector
+  returned the wrong selector.
+
 # 5.1.0
 
 * `ComponentResolver#test_body` returns a JSON blob of the components keys and values instead of just the values.

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '5.1.0'
+  VERSION = '6.0.0'
 end


### PR DESCRIPTION
The changes in this version broke tests in specialist-frontend which hardcoded
knowledge about the substitute tags. On that basis, we made this a MAJOR
version change.
