### PR TITLE
Loosen Nokogiri dependency

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "slimmer"
 
-  s.add_dependency 'nokogiri', '~> 1.5.0'
+  s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.7.0'
   s.add_dependency 'rack', '>= 1.3.5'
   s.add_dependency 'plek', '>= 1.1.0'
   s.add_dependency 'json'


### PR DESCRIPTION
Rails 4.2 needs Nokogiri 1.6.0 and above. Loosening this dependency lets us
upgrade apps using Slimmer to Rails 4.2.

Tested successfully with Nokogiri 1.6.0 and 1.6.4.1
