### PR TITLE
Remove business proposition custom variable

### DIFF
--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -14,7 +14,6 @@ module Slimmer::Processors
       if @artefact
         custom_vars << set_custom_var_downcase(1, "Section", @artefact.primary_root_section["title"]) if @artefact.primary_root_section
         custom_vars << set_multivalue_custom_var(3, "NeedID", @artefact.need_ids)
-        custom_vars << set_custom_var_downcase(4, "Proposition", (@artefact.business_proposition ? 'business' : 'citizen')) unless @artefact.business_proposition.nil?
       end
       custom_vars << set_custom_var(9, "Organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER])
       custom_vars << set_custom_var(10, "WorldLocations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER])
@@ -44,4 +43,3 @@ module Slimmer::Processors
     end
   end
 end
-

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -57,7 +57,6 @@ module GoogleAnalyticsTest
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
       artefact["details"].merge!(
         "need_ids" => [100001,100002],
-        "business_proposition" => true,
       )
       headers = {
         Slimmer::Headers::FORMAT_HEADER => "custard",
@@ -94,20 +93,12 @@ module GoogleAnalyticsTest
       assert_set_var "NeedID", "100001,100002", govuk
     end
 
-    def test_should_pass_proposition_to_GA
-      assert_custom_var 4, "Proposition", "business", PAGE_LEVEL_EVENT
-    end
-
     def test_should_pass_organisation_to_GA
       assert_custom_var 9, "Organisations", "<P1><D422>", PAGE_LEVEL_EVENT
     end
 
     def test_should_pass_world_location_to_GA
       assert_custom_var 10, "WorldLocations", "<WL3>", PAGE_LEVEL_EVENT
-    end
-
-    def test_should_set_proposition_in_GOVUK_object
-      assert_set_var "Proposition", "business", govuk
     end
 
     def test_should_pass_result_count_to_GA
@@ -158,10 +149,6 @@ module GoogleAnalyticsTest
       refute_custom_var "NeedID"
     end
 
-    def test_should_omit_proposition
-      refute_custom_var "Proposition"
-    end
-
     def test_should_omit_organisations
       refute_custom_var "Organisations"
     end
@@ -180,7 +167,6 @@ module GoogleAnalyticsTest
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
       artefact["details"].merge!(
         "need_ids" => [100001, 100002],
-        "business_proposition" => true
       )
       headers = {
         Slimmer::Headers::RESULT_COUNT_HEADER => "3",


### PR DESCRIPTION
As part of moving analytics from classic to universal, we’ve audited the custom variables being set and whether they are still being used. Ash identified this variable as being unused and marked it for deletion.

Part of https://www.pivotaltracker.com/story/show/87740262