### PR TITLE
Remove `GOVUK.Analytics` variables

### DIFF
--- a/lib/slimmer/processors/google_analytics_configurator.rb
+++ b/lib/slimmer/processors/google_analytics_configurator.rb
@@ -38,8 +38,7 @@ module Slimmer::Processors
 
     def set_custom_var(slot, name, value)
       return nil unless value
-      response = "_gaq.push(#{JSON.dump([ "_setCustomVar", slot, name, value, PAGE_LEVEL_EVENT])});\n"
-      response + "GOVUK.Analytics.#{name} = \"#{value}\";"
+      "_gaq.push(#{JSON.dump([ "_setCustomVar", slot, name, value, PAGE_LEVEL_EVENT])});\n"
     end
   end
 end

--- a/test/fixtures/wrapper.html.erb
+++ b/test/fixtures/wrapper.html.erb
@@ -2,11 +2,6 @@
 <html>
   <head>
     <title>Slimmer, yay!</title>
-    <script id="ga-params" type="text/javascript">
-      var GOVUK = GOVUK || {};
-      GOVUK.Analytics = GOVUK.Analytics || {};
-      var _gaq = _gaq || [];
-    </script>
   </head>
   <body>
     <header id="global-header"><h1>I AM A TITLE</h1></header>
@@ -20,5 +15,6 @@
 
     <footer id="footer">
     </footer>
+    <script id="ga-params">var _gaq = _gaq || [];</script>
   </body>
 </html>

--- a/test/processors/google_analytics_test.rb
+++ b/test/processors/google_analytics_test.rb
@@ -23,23 +23,12 @@ module GoogleAnalyticsTest
       context.eval("_gaq");
     end
 
-    def govuk
-      js = Nokogiri::HTML(last_response.body).at_css("#ga-params").text
-      context = V8::Context.new
-      context.eval(js)
-      context.eval("GOVUK.Analytics");
-    end
-
     def assert_custom_var(slot, name, value, page_level)
       # Ruby Racer JS arrays don't accept range indexing, so we must
       # use a slightly longer workaround
       vars = gaq.select { |a| a[0] == "_setCustomVar" }.
                  map { |a| (1..4).map { |i| a[i] } }
       assert_includes vars, [slot, name, value, page_level]
-    end
-
-    def assert_set_var(name, value, object)
-      assert_equal value, object.find { |each| each[0] == name }[1]
     end
 
     def refute_custom_var(name)
@@ -73,24 +62,12 @@ module GoogleAnalyticsTest
       assert_custom_var 1, "Section", "rhubarb", PAGE_LEVEL_EVENT
     end
 
-    def test_should_set_section_in_GOVUK_object
-      assert_set_var "Section", "rhubarb", govuk
-    end
-
     def test_should_pass_internal_format_name_to_GA
       assert_custom_var 2, "Format", "custard", PAGE_LEVEL_EVENT
     end
 
-    def test_should_set_internal_format_name_in_GOVUK_object
-      assert_set_var "Format", "custard", govuk
-    end
-
     def test_should_pass_need_ids_to_GA
       assert_custom_var 3, "NeedID", "100001,100002", PAGE_LEVEL_EVENT
-    end
-
-    def test_should_set_need_ids_in_GOVUK_object
-      assert_set_var "NeedID", "100001,100002", govuk
     end
 
     def test_should_pass_organisation_to_GA
@@ -103,10 +80,6 @@ module GoogleAnalyticsTest
 
     def test_should_pass_result_count_to_GA
       assert_custom_var 5, "ResultCount", "3", PAGE_LEVEL_EVENT
-    end
-
-    def test_should_set_result_count_in_GOVUK_object
-      assert_set_var "ResultCount", "3", govuk
     end
   end
 


### PR DESCRIPTION
These variables were added to test guide success tracking in:
https://github.com/alphagov/slimmer/pull/5

That success tracking was removed in:
https://github.com/alphagov/static/pull/522

They are no longer used and the “Analytics” namespace is being removed.