### PR TITLE
Add a header to remove search bar

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -35,6 +35,7 @@ module Slimmer
     autoload :SearchIndexSetter, 'slimmer/processors/search_index_setter'
     autoload :SearchPathSetter, 'slimmer/processors/search_path_setter'
     autoload :SearchParameterInserter, 'slimmer/processors/search_parameter_inserter'
+    autoload :SearchRemover, 'slimmer/processors/search_remover'
     autoload :SectionInserter, 'slimmer/processors/section_inserter'
     autoload :TagMover, 'slimmer/processors/tag_mover'
     autoload :TitleInserter, 'slimmer/processors/title_inserter'

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -17,6 +17,7 @@ module Slimmer
       section:              "Section",
       skip:                 "Skip",
       template:             "Template",
+      remove_search:        "Remove-Search",
     }
 
     APPLICATION_NAME_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:application_name]}"
@@ -32,6 +33,7 @@ module Slimmer
     SEARCH_PARAMETERS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:search_parameters]}"
     SKIP_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:skip]}"
     TEMPLATE_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:template]}"
+    REMOVE_SEARCH_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_search]}"
 
     def set_slimmer_headers(hash)
       raise InvalidHeader if (hash.keys - SLIMMER_HEADER_MAPPING.keys).any?

--- a/lib/slimmer/processors/search_remover.rb
+++ b/lib/slimmer/processors/search_remover.rb
@@ -1,0 +1,17 @@
+module Slimmer::Processors
+  class SearchRemover
+    def initialize(headers)
+      @headers = headers
+    end
+
+    def filter(src,dest)
+      if @headers.include?(Slimmer::Headers::REMOVE_SEARCH_HEADER)
+        search = dest.at_css("#global-header #search")
+        search.remove if search
+
+        search_link = dest.at_css("#global-header a[href='#search']")
+        search_link.remove if search_link
+      end
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -126,6 +126,7 @@ module Slimmer
                                                response.headers,
                                                wrapper_id),
         Processors::MetaViewportRemover.new(self, response.headers),
+        Processors::SearchRemover.new(response.headers),
       ]
 
       template_name = response.headers[Headers::TEMPLATE_HEADER] || 'wrapper'

--- a/test/processors/search_remover_test.rb
+++ b/test/processors/search_remover_test.rb
@@ -1,0 +1,62 @@
+require_relative "../test_helper"
+
+class SearchRemoverTest < MiniTest::Test
+  def setup
+    super
+    @template = as_nokogiri %{
+      <html>
+        <head>
+        </head>
+        <body>
+          <div id='global-header'>
+            <a href='#search'></a>
+            <div id='search'></div>
+          </div>
+          <div id='search'></div>
+        </body>
+      </html>
+    }
+  end
+
+  def test_should_remove_search_from_template_if_header_is_set
+
+    headers = { Slimmer::Headers::REMOVE_SEARCH_HEADER => true }
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_not_in @template, "#global-header #search"
+    assert_in @template, "#search"
+
+  end
+
+  def test_should_not_remove_search_from_template_if_header_is_not_set
+
+    headers = {}
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_in @template, "#global-header #search"
+  end
+
+  def test_should_remove_search_link_from_template_if_header_is_set
+
+    headers = { Slimmer::Headers::REMOVE_SEARCH_HEADER => true }
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_not_in @template, "#global-header a[href='#search']"
+  end
+
+  def test_should_not_remove_search_link_from_template_if_header_is_not_set
+
+    headers = {}
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_in @template, "#global-header a[href='#search']"
+  end
+end


### PR DESCRIPTION
For manuals we need to remove the search box in the page header as we're going to be adding one that provides custom searching within the manual.
This commit adds a new `header` that you can call from your app that will remove the search box from the top of the page.
You can call it by adding the following code to your applications ApplicationController in a before filter:
`set_slimmer_headers(remove_search: true)`

Pivotal:https://www.pivotaltracker.com/n/projects/1261204/stories/88435634

This PR defines the header and adds the processor for the header and a test for the processor.

Further work
- After this header is merged we should start using it in frontend too which currently uses CSS to `display:none` the top search box on /search and the homepage (I'll open a PR...)