### PR TITLE
Obey strict mode = false in dev and test

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -3,6 +3,8 @@ require 'slimmer/govuk_request_id'
 
 module Slimmer
   class Skin
+    TemplateParseError = Class.new(RuntimeError)
+
     attr_accessor :template_cache, :asset_host, :logger, :strict, :options
 
     def initialize options = {}
@@ -11,7 +13,7 @@ module Slimmer
       @template_cache = options[:cache]
 
       @logger = options[:logger] || NullLogger.instance
-      @strict = options[:strict] || (%w{development test}.include?(ENV['RACK_ENV']))
+      @strict = options[:strict].nil? ? (%w{development test}.include?(ENV['RACK_ENV'])) : options[:strict]
     end
 
     def template(template_name)
@@ -53,7 +55,7 @@ module Slimmer
           message = "In #{description_for_error_message}: '#{error.message}' at line #{error.line} col #{error.column} (code #{error.code}).\n"
           message << "Add ?skip_slimmer=1 to the url to show the raw backend request.\n\n"
           message << context(html, error)
-          raise message
+          raise TemplateParseError.new(message)
         end
       end
 

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -84,6 +84,76 @@ describe Slimmer::Skin do
         skin.template 'example'
       end
     end
+
+    describe "strict mode" do
+      let(:invalid_html) { '<html><div id="foo"></div><div id="foo"></div></html>' }
+      let(:rack_env) { 'production' }
+
+      before do
+        ENV["RACK_ENV"] = rack_env
+      end
+
+      after do
+        ENV["RACK_ENV"] = "test"
+      end
+
+      subject do
+        skin = Slimmer::Skin.new strict: strict_mode
+
+        skin.parse_html invalid_html, "Example HTML"
+      end
+
+      describe "when true" do
+        let(:strict_mode) { true }
+
+        it "raises a validation error" do
+          assert_raises(Slimmer::Skin::TemplateParseError) { subject }
+        end
+      end
+
+      describe "when nil in development" do
+        let(:strict_mode) { nil }
+        let(:rack_env) { "development" }
+
+        it "raises a validation error" do
+          assert_raises(Slimmer::Skin::TemplateParseError) { subject }
+        end
+      end
+
+      describe "when nil in test" do
+        let(:strict_mode) { nil }
+        let(:rack_env) { "test" }
+
+        it "raises a validation error" do
+          assert_raises(Slimmer::Skin::TemplateParseError) { subject }
+        end
+      end
+
+      describe "when nil in production" do
+        let(:strict_mode) { nil }
+
+        it "parses correctly" do
+          assert_kind_of Nokogiri::HTML::Document, subject
+        end
+      end
+
+      describe "when false in development" do
+        let(:strict_mode) { false }
+        let(:rack_env) { "development" }
+
+        it "parses correctly" do
+          assert_kind_of Nokogiri::HTML::Document, subject
+        end
+      end
+
+      describe "when false in production" do
+        let(:strict_mode) { false }
+
+        it "parses correctly" do
+          assert_kind_of Nokogiri::HTML::Document, subject
+        end
+      end
+    end
   end
 
   describe "parsing artefact from header" do


### PR DESCRIPTION
This is needed for Whitehall's Rails 4.2 upgrade. New versions of Nokogiri specified by rails-dom-testing now raise validation errors for duplicate DOM ids. This occurs in at least the organisations list because e.g. PM’s office is included on its own and also as an organisation that works with the Cabinet Office.