### PR TITLE
Output rendering application in meta tag

### DIFF
--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -1,8 +1,9 @@
 module Slimmer::Processors
   class MetadataInserter
-    def initialize(response, artefact)
+    def initialize(response, artefact, app_name)
       @headers = response.headers
       @artefact = artefact
+      @app_name = app_name
     end
 
     def filter(src, dest)
@@ -17,6 +18,7 @@ module Slimmer::Processors
       add_meta_tag('analytics:world-locations', @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head)
       add_meta_tag('format', @headers[Slimmer::Headers::FORMAT_HEADER], head)
       add_meta_tag('search-result-count', @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head)
+      add_meta_tag('rendering-application', @app_name, head)
     end
 
   private

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -3,7 +3,12 @@ module Slimmer
     config.slimmer = ActiveSupport::OrderedOptions.new
 
     initializer "slimmer.configure" do |app|
-      app.middleware.use Slimmer::App, app.config.slimmer.to_hash
+      slimmer_config = app.config.slimmer.to_hash
+
+      app_name = app.class.parent_name
+      slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
+
+      app.middleware.use Slimmer::App, slimmer_config
     end
   end
 end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -117,7 +117,7 @@ module Slimmer
         Processors::BodyClassCopier.new,
         Processors::HeaderContextInserter.new(),
         Processors::SectionInserter.new(artefact),
-        Processors::MetadataInserter.new(response, artefact),
+        Processors::MetadataInserter.new(response, artefact, options[:app_name]),
         Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
         Processors::RelatedItemsInserter.new(self, artefact),


### PR DESCRIPTION
I am interested in thoughts on this being a thing that should exist as much as the technical implementation of this change. Do you think this is a good idea?

New pull request because I force pushed to the [last one](https://github.com/alphagov/slimmer/pull/125) while it was closed so can't reopen it :cry: 

-----

It would be really useful to be able to segment analytics by rendering
application. It would let us have things like JavaScript errors per
application and page timings per application.

This change takes the class name of the currently running application
and adds it as a meta tag which can then be read by JavaScript.