### PR TITLE
Use GOVUK_APP_NAME if it is set

### DIFF
--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -5,7 +5,7 @@ module Slimmer
     initializer "slimmer.configure" do |app|
       slimmer_config = app.config.slimmer.to_hash
 
-      app_name = app.class.parent_name
+      app_name = ENV['GOVUK_APP_NAME'] || app.class.parent_name
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config


### PR DESCRIPTION
Rather than using the applications class name use the GOVU_APP_NAME
environment variable if it is around. This will then better match the
names we use within the infrastructure, and also match the vhost
name.