### PR TITLE
Bump to 8.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 8.2.1
+
+* Update rendering app meta tag to use GOVUK_APP_NAME env variable if available
+
 # 8.2.0
 
 * Add meta tag for currently running application

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '8.2.0'
+  VERSION = '8.2.1'
 end


### PR DESCRIPTION
Update rendering app meta tag to use GOVUK_APP_NAME env variable if
available