### PR TITLE
Copying meta tags with property

### DIFF
--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -4,6 +4,7 @@ module Slimmer::Processors
       move_tags(src, dest, 'script', :dest_node => 'body', :keys => ['src', 'inner_html'])
       move_tags(src, dest, 'link',   :must_have => ['href'])
       move_tags(src, dest, 'meta',   :must_have => ['name', 'content'], :keys => ['name', 'content', 'http-equiv'])
+      move_tags(src, dest, 'meta',   :must_have => ['property', 'content'], :keys => ['property', 'content'])
     end
 
     def include_tag?(node, min_attrs)

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -13,6 +13,9 @@ class TagMoverTest < MiniTest::Test
           <meta name="no_content" />
           <meta content="no_name" />
           <meta name="duplicate" content="name and content" />
+          <meta property="p:baz" content="bat" />
+          <meta property="p:empty" />
+          <meta property="p:duplicate" content="name and content" />
         </head>
         <body class="mainstream">
           <div id="wrapper"></div>
@@ -26,6 +29,7 @@ class TagMoverTest < MiniTest::Test
         <head>
           <link rel="stylesheet" href="http://www.example.com/duplicate.css" />
           <meta name="duplicate" content="name and content" />
+          <meta property="p:duplicate" content="name and content" />
         </head>
         <body class="mainstream">
           <div id="wrapper"></div>
@@ -73,7 +77,19 @@ class TagMoverTest < MiniTest::Test
     assert_not_in @template, "meta[content='no_name']"
   end
 
+  def test_should_move_meta_tags_with_property_into_the_head
+    assert_in @template, "meta[property='p:baz'][content='bat']", nil, "Should have moved the a:baz=bat meta (property) tag"
+  end
+
+  def test_should_ignore_meta_tags_with_property_but_no_content
+    assert_not_in @template, "meta[property='p:empty']"
+  end
+
   def test_should_ignore_meta_tags_already_in_the_destination_with_the_same_name_and_content
     assert @template.css("meta[name='duplicate'][content='name and content']").length == 1, "Expected there to only be one duplicate=name and content meta tag."
+  end
+
+  def test_should_ignore_meta_tags_with_property_already_in_the_destination_with_the_same_name_and_content
+    assert @template.css("meta[property='p:duplicate'][content='name and content']").length == 1, "Expected there to only be one duplicate=name and content meta (property) tag."
   end
 end


### PR DESCRIPTION
Previously, slimmer skipped meta tags with no name set, which dropped
OpenGraph and Twitter meta tags. This now separately copies these
over.

Also adding tests for meta tag with property and test for duplicate property meta tags

NB was previously discussed in #132, but due to rebase / squash and exisiting commits to forked repo, had to abandon that PR and open this one...