### PR TITLE
Run GOV.UK ruby linter as part of CI builds

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -17,6 +17,8 @@ done
 
 unset RBENV_VERSION
 
+bundle exec govuk-lint-ruby --diff --cached --format clang bin lib test
+
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem --trace
 fi

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'gds-api-adapters', '2.7.1'
   s.add_development_dependency 'timecop', '~> 0.5.1'
+  s.add_development_dependency 'govuk-lint', '~> 0.2.0'
   s.files         = Dir[
     'README.md',
     'CHANGELOG.md',


### PR DESCRIPTION
It's configured to only report on the diff of changes, not the whole repo.

I've run it against the whole repo and there a reasonable amount of violations,
and bulk fixing them is usually contentious, so i'm ignoring that for now.

With this linting in place at least nothing new will violate the style guide
and hopefully this will mean computers can give the feedback on style issues,
rather humans, which computers are better at and avoids humans having to give
nitpick-y feedback.

CC @boffbowsh who wrote the linting gem, and @edds, @alext and @jamiecobbett as people who've worked on slimmer.

Thoughts?