### PR TITLE
Version 8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 8.4.0
+
+* Add support for moving `meta` tags that use `property` attribute
+
+  Previously only meta tags using the `name` attribute were moved into the
+  `head` of the page. This allows OpenGraph-style meta tags to be included
+  by an application using Slimmer.
+
 # 8.3.0
 
 * Add support for 403 error page.

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '8.3.0'
+  VERSION = '8.4.0'
 end


### PR DESCRIPTION
**Versioning**:

This could be minor or patch, depending how you look at it, so made it minor to be on the safe side.

**Changes** ([diff](https://github.com/alphagov/slimmer/compare/v8.3.0...2e87a0a367f8e671fe3ec33820d528b1b2a1bfcf)):

* Add support for moving `meta` tags that use `property` attribute

  Previously only meta tags using the `name` attribute were moved into the
  `head` of the page. This allows OpenGraph-style meta tags to be included
  by an application using Slimmer.

**Contributors**: 
- @gilesdring 
