### PR TITLE
Add optional arg to template resolver call

### DIFF
--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -11,7 +11,7 @@ module Slimmer
       false
     end
 
-    def find_templates(name, prefix, partial, details)
+    def find_templates(name, prefix, partial, details, outside_app_allowed = false)
       return [] unless prefix == 'govuk_component'
       cache = Cache.instance
 

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rack-test', '~> 0.6.1'
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'webmock', '1.18.0'
-  s.add_development_dependency 'therubyracer', '~> 0.10.2'
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'gds-api-adapters', '2.7.1'
   s.add_development_dependency 'timecop', '~> 0.5.1'

--- a/test/component_resolver_test.rb
+++ b/test/component_resolver_test.rb
@@ -7,14 +7,14 @@ describe Slimmer::ComponentResolver do
     end
 
     it "should return nothing if the prefix doesn't match 'govuk_component'" do
-      assert_equal [], @resolver.find_templates('name', 'prefix', false, {})
+      assert_equal [], @resolver.find_templates('name', 'prefix', false, {}, false)
     end
 
     it "should request a valid template from the server" do
       expected_url = "http://static.dev.gov.uk/templates/govuk_component/name.raw.html.erb"
       stub_request(:get, expected_url).to_return :body => "<foo />"
 
-      templates = @resolver.find_templates('name', 'govuk_component', false, {})
+      templates = @resolver.find_templates('name', 'govuk_component', false, {}, false)
       assert_requested :get, expected_url
       assert_equal '<foo />', templates.first.args[0]
     end
@@ -22,7 +22,7 @@ describe Slimmer::ComponentResolver do
     it "should return a known template in test mode" do
       @resolver.expects(:test?).returns(true)
 
-      templates = @resolver.find_templates('name', 'govuk_component', false, {})
+      templates = @resolver.find_templates('name', 'govuk_component', false, {}, false)
       assert_match /<test-govuk-component data-template="govuk_component-name">/, templates.first.args[0]
     end
   end


### PR DESCRIPTION
CVE-2016-0752 was announced, the fix for which changed how Rails calls
template resolvers. It added an optional argument (defaulting to false)
which controls whether the template resolver should find templates
outside `Rails.root`. In Slimmer’s case, we take any requested
templates with a prefix of `govuk_component`and resolve them with the
static service over HTTP. The local file system is never touched.
Therefore, it’s safe to simply add the new argument here but ignore it
and carry on as normal.

/cc @dsingleton