### PR TITLE
Accept full and partial component paths in resolver

### DIFF
--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -56,7 +56,8 @@ module Slimmer
     end
 
     def template_url(template_path)
-      [static_host, "templates", "#{template_path}.raw.html.erb"].join('/')
+      path = template_path.sub(/\.raw(\.html\.erb)?$/, '')
+      [static_host, "templates", "#{path}.raw.html.erb"].join('/')
     end
 
     def static_host

--- a/test/component_resolver_test.rb
+++ b/test/component_resolver_test.rb
@@ -11,12 +11,15 @@ describe Slimmer::ComponentResolver do
     end
 
     it "should request a valid template from the server" do
-      expected_url = "http://static.dev.gov.uk/templates/govuk_component/name.raw.html.erb"
-      stub_request(:get, expected_url).to_return :body => "<foo />"
+      assert_valid_template_requested('name', 'name.raw.html.erb')
+    end
 
-      templates = @resolver.find_templates('name', 'govuk_component', false, {}, false)
-      assert_requested :get, expected_url
-      assert_equal '<foo />', templates.first.args[0]
+    it "should request a valid template from the server when a raw template is requested" do
+      assert_valid_template_requested('name.raw', 'name.raw.html.erb')
+    end
+
+    it "should request a valid template from the server when the full template filename is requested" do
+      assert_valid_template_requested('name.raw.html.erb', 'name.raw.html.erb')
     end
 
     it "should return a known template in test mode" do
@@ -25,5 +28,14 @@ describe Slimmer::ComponentResolver do
       templates = @resolver.find_templates('name', 'govuk_component', false, {}, false)
       assert_match /<test-govuk-component data-template="govuk_component-name">/, templates.first.args[0]
     end
+  end
+
+  def assert_valid_template_requested(requested, expected)
+    expected_url = "http://static.dev.gov.uk/templates/govuk_component/#{expected}"
+    stub_request(:get, expected_url).to_return body: "<foo />"
+
+    templates = @resolver.find_templates(requested, 'govuk_component', false, {}, false)
+    assert_requested :get, expected_url
+    assert_equal '<foo />', templates.first.args[0]
   end
 end


### PR DESCRIPTION
For components to be able to call other components (composeable components) they need to use a component path that includes `.raw` (this is not a standard Rails format, but a convention
we use).

## Example

Consider the following component:
```erb
<div class="govuk-govspeak-html-publication">
  <%= partial: 'govuk_component/govspeak', locals: govspeak_locals %>
</div>
```
In this example, the application can make a request for the `govspeak-html-publication` component (`govuk_component/govspeak-html-publication.raw.html.erb`), and then a subsequent request for `govspeak`, both will work. Slimmer converts the component name into a filename.

When testing in static we don't use slimmer, so the test attempts to load `govuk_component/govspeak.html.erb` rather than `govspeak.raw.html.erb` version. That files doesn't exist and the tests fail.

Changing the nested component to one that works with tests:
```erb
<div class="govuk-govspeak-html-publication">
  <%= render file: 'govuk_component/govspeak.raw', locals: govspeak_locals %>
</div>
```
This works locally, but when requested by an application through slimmer, slimmer would take `govspeak.raw` and request `govspeak.raw.raw.html.erb`.

The simplest approach is to allow apps to request components using the complete template filename, the raw variant, or just its name. This avoids bespoke template resolver logic.

There is a longer term plan to move component loading to its own API, rather than riding on the Rails template resolver magic.

cc @dsingleton @benlovell 