### PR TITLE
Rescue SSL errors in Skin#load_template

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -28,11 +28,7 @@ module Slimmer
       response.body
     rescue RestClient::Exception => e
       raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
-    rescue Errno::ECONNREFUSED => e
-      raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
-    rescue SocketError => e
-      raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
-    rescue OpenSSL::SSL::SSLError => e
+    rescue Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError => e
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     end
 

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -32,6 +32,8 @@ module Slimmer
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     rescue SocketError => e
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+    rescue OpenSSL::SSL::SSLError => e
+      raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     end
 
     def template_url(template_name)

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -84,6 +84,17 @@ describe Slimmer::Skin do
         skin.template 'example'
       end
     end
+
+    it "should raise appropriate exception when encountering an SSL error" do
+      skin = Slimmer::Skin.new asset_host: "https://bad-ssl.domain/", cache: Slimmer::Cache.instance
+
+      expected_url = "https://bad-ssl.domain/templates/example.html.erb"
+      stub_request(:get, expected_url).to_raise(OpenSSL::SSL::SSLError)
+
+      assert_raises(Slimmer::CouldNotRetrieveTemplate) do
+        skin.template 'example'
+      end
+    end
   end
 
   describe "parsing artefact from header" do


### PR DESCRIPTION
Raise a custom `CouldNotRetrieveTemplate` exception when a connection to the assets server can't be made because of some SSL problem.

I've seen this problem a few times in development and at least once in Smart Answers production (see [errbit error][1]).

In case it's useful, I used cURL to make the request when I experienced this problem in development:

    $ curl -v \
    https://assets-origin.integration.publishing.service.gov.uk/templates/wrapper.html.erb
    *   Trying 31.210.245.98...
    * Connected to
    * assets-origin.integration.publishing.service.gov.uk
    * (31.210.245.98) port 443 (#0)
    * Server aborted the SSL handshake
    * Closing connection 0
    curl: (35) Server aborted the SSL handshake
    Trying to connect to assets server using cURL gives this information:

[1]:
https://errbit.publishing.service.gov.uk/apps/533c35ae0da1159384044f5f/problems/56e7a162657863326adf0600