### PR TITLE
Bump version to 9.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 9.2.0
+
+* Raise a custom `CouldNotRetrieveTemplate` exception when a connection to the assets server can't be made because of an SSL problem (PR #143).
+
 # 9.1.0
 
 * Allow applications to request components using full or partial component

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '9.1.0'
+  VERSION = '9.2.0'
 end


### PR DESCRIPTION
I've incremented the minor version as I believe the change in PR #143
(the only change made since 9.1.0) counts as "add(ing) functionality in
a backwards-compatible manner"[1].

[1]: http://semver.org/