### PR TITLE
Fix publishing asset host in test templates

### DIFF
--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -16,8 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/header-footer-only.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/header-footer-only.js" type="text/javascript"></script>
   </body>
 </html>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -16,8 +16,8 @@
 
     <footer id="footer"></footer>
 
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/govuk-template.js" type="text/javascript"></script>
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
-    <script src="https://assets.digital.cabinet-office.gov.uk/static/application.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/govuk-template.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/libs/jquery/jquery-1.7.2.js" type="text/javascript"></script>
+    <script src="https://assets.publishing.service.gov.uk/static/application.js" type="text/javascript"></script>
   </body>
 </html>


### PR DESCRIPTION
The host for GOV.UK assets has changed. This was causing test failures as we are asserting on a 200 SUCCESS response however we were receiving a 301 MOVED PERMANENTLY. 