### PR TITLE
Replace deprecated `before_filter` calls

### DIFF
--- a/lib/slimmer/shared_templates.rb
+++ b/lib/slimmer/shared_templates.rb
@@ -1,7 +1,7 @@
 module Slimmer
   module SharedTemplates
     def self.included into
-      into.before_filter :add_shared_templates
+      into.before_action :add_shared_templates
     end
 
     def add_shared_templates


### PR DESCRIPTION
The `before_filter` method is deprecated and will be removed in Rails 5.1. Fixing now so that we don't pollute our logs with depreciation warnings.