### PR TITLE
Autoload i18n backend

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -20,6 +20,7 @@ module Slimmer
 
   autoload :SharedTemplates, 'slimmer/shared_templates'
   autoload :ComponentResolver, 'slimmer/component_resolver'
+  autoload :I18nBackend, 'slimmer/i18n_backend'
 
   module Processors
     autoload :BodyClassCopier, 'slimmer/processors/body_class_copier'

--- a/lib/slimmer/i18n_backend.rb
+++ b/lib/slimmer/i18n_backend.rb
@@ -42,6 +42,8 @@ module Slimmer
       json_data = fetch(url)
       translations = JSON.parse(json_data)
       flatten_translations(locale, translations, false, false)
+    rescue TemplateNotFoundException
+      {}
     end
 
     def fetch(url)

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -9,6 +9,8 @@ module Slimmer
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config
+
+      I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
     end
   end
 end

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -9,8 +9,6 @@ module Slimmer
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config
-
-      I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
     end
   end
 end

--- a/lib/slimmer/shared_templates.rb
+++ b/lib/slimmer/shared_templates.rb
@@ -5,6 +5,8 @@ module Slimmer
     end
 
     def add_shared_templates
+      I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
+
       append_view_path Slimmer::ComponentResolver.new
     end
   end

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "slimmer"
 
   s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.7.0'
-  s.add_dependency 'rack', '~> 1.0'
+  s.add_dependency 'rack'
   s.add_dependency 'plek', '>= 1.1.0'
   s.add_dependency 'json'
   s.add_dependency 'null_logger'
   s.add_dependency 'rest-client'
-  s.add_dependency 'activesupport', '~> 4.0'
+  s.add_dependency 'activesupport'
 
   s.test_files    = Dir['test/**/*']
   s.add_development_dependency 'minitest', '~> 5.4'

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -17,12 +17,12 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "slimmer"
 
   s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.7.0'
-  s.add_dependency 'rack', '>= 1.3.5'
+  s.add_dependency 'rack', '~> 1.0'
   s.add_dependency 'plek', '>= 1.1.0'
   s.add_dependency 'json'
   s.add_dependency 'null_logger'
   s.add_dependency 'rest-client'
-  s.add_dependency 'activesupport'
+  s.add_dependency 'activesupport', '~> 4.0'
 
   s.test_files    = Dir['test/**/*']
   s.add_development_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
Continues the work started in https://github.com/alphagov/static/pull/505

Let's slimmer chain it's own i18n backend to the frontend app that consumes it.