### PR TITLE
Don't chain i18n backend multiple times

### DIFF
--- a/lib/slimmer/shared_templates.rb
+++ b/lib/slimmer/shared_templates.rb
@@ -5,9 +5,17 @@ module Slimmer
     end
 
     def add_shared_templates
-      I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
-
       append_view_path Slimmer::ComponentResolver.new
+
+      return if slimmer_backend_included?
+      I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
+    end
+
+  private
+
+    def slimmer_backend_included?
+      I18n.backend.is_a?(I18n::Backend::Chain) &&
+        I18n.backend.backends.any? { |b| b.is_a? Slimmer::I18nBackend }
     end
   end
 end


### PR DESCRIPTION
Checks if the Slimmer i18n backend has already been chained onto the
backend before adding it. This fixes a recursion issue where over time
the I18n backend would become a chained backend of chained backends
many times over.

/cc @gpeng @nickcolley 