### PR TITLE
Fix component locale stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ within(shared_component_selector('title')) do
 end
 ```
 
+### RSpec
+
+Add the following code to spec/spec_helper:
+
+```rb
+require 'slimmer/rspec'
+```
+
 ## The name
 
 Slimmer was extracted from a much larger project called 'skinner'. 'slimmer' referred to the size

--- a/lib/slimmer/rspec.rb
+++ b/lib/slimmer/rspec.rb
@@ -1,0 +1,11 @@
+require 'rspec/core'
+
+require 'slimmer'
+require 'slimmer/test'
+require 'slimmer/test_helpers/shared_templates'
+
+RSpec.configure do |config|
+  config.include Slimmer::TestHelpers::SharedTemplates
+
+  config.before { stub_shared_component_locales }
+end

--- a/lib/slimmer/test_helpers/shared_templates.rb
+++ b/lib/slimmer/test_helpers/shared_templates.rb
@@ -3,10 +3,8 @@ module Slimmer
     module SharedTemplates
       def stub_shared_component_locales
         stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/.+/).
-          with(headers: { 'Accept' => '*/*; q=0.5, application/xml', 'Accept-Encoding' => 'gzip, deflate', 'User-Agent' => 'Ruby' }).
           to_return(status: 400, headers: {})
         stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/en/).
-          with(headers: { 'Accept' => '*/*; q=0.5, application/xml', 'Accept-Encoding' => ' gzip, deflate', 'User-Agent' => 'Ruby' }).
           to_return(status: 200, body: '{}', headers: {})
       end
 

--- a/lib/slimmer/test_helpers/shared_templates.rb
+++ b/lib/slimmer/test_helpers/shared_templates.rb
@@ -1,3 +1,5 @@
+require 'webmock'
+
 module Slimmer
   module TestHelpers
     module SharedTemplates

--- a/lib/slimmer/test_helpers/shared_templates.rb
+++ b/lib/slimmer/test_helpers/shared_templates.rb
@@ -4,7 +4,7 @@ module Slimmer
       def stub_shared_component_locales
         stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/.+/).
           to_return(status: 400, headers: {})
-        stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/en/).
+        stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales/).
           to_return(status: 200, body: '{}', headers: {})
       end
 

--- a/lib/slimmer/test_helpers/shared_templates.rb
+++ b/lib/slimmer/test_helpers/shared_templates.rb
@@ -2,10 +2,10 @@ module Slimmer
   module TestHelpers
     module SharedTemplates
       def stub_shared_component_locales
-        stub_request(:get, /https:\/\/\S+.gov.uk\/templates\/locales\/.+/).
+        stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/.+/).
           with(headers: { 'Accept' => '*/*; q=0.5, application/xml', 'Accept-Encoding' => 'gzip, deflate', 'User-Agent' => 'Ruby' }).
           to_return(status: 400, headers: {})
-        stub_request(:get, /https:\/\/\S+.gov.uk\/templates\/locales\/en/).
+        stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/en/).
           with(headers: { 'Accept' => '*/*; q=0.5, application/xml', 'Accept-Encoding' => ' gzip, deflate', 'User-Agent' => 'Ruby' }).
           to_return(status: 200, body: '{}', headers: {})
       end


### PR DESCRIPTION
These changes make the `stub_shared_component_locales` test helper more robust so that it correctly stubs requests originating from a host application.

Currently Slimmer will attempt to make external HTTP requests to fetch locale information when rendering its templates.

```
Failure/Error: <%= render partial: 'govuk_component/beta_label' %>

WebMock::NetConnectNotAllowedError:
  Real HTTP connections are disabled. Unregistered request: GET http://static.dev.gov.uk/templates/locales with headers {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}

You can stub this request with the following snippet:

stub_request(:get, "http://static.dev.gov.uk/templates/locales").
  with(:headers => {'Accept'=>'*/*; q=0.5, application/xml', 'Accept-Encoding'=>'gzip, deflate', 'User-Agent'=>'Ruby'}).
  to_return(:status => 200, :body => "", :headers => {})
```

It also adds an RSpec helper that makes it easy for host applications to configure Slimmer correctly under test.