### PR TITLE
Make it easier to run the linter locally

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@ require "bundler/gem_tasks"
 require "rdoc/task"
 require 'rake/testtask'
 
+Dir.glob('lib/tasks/*.rake').each { |r| import r }
+
 RDoc::Task.new do |rd|
   rd.rdoc_files.include("lib/**/*.rb")
   rd.rdoc_dir = "rdoc"
@@ -22,4 +24,4 @@ task :publish_gem do |t|
   puts "Published #{gem}" if gem
 end
 
-task :default => :test
+task :default => [:test, :lint]

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -40,7 +40,7 @@ test 3.2.x 2.1
 test 3.2.x 1.9.3
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
-bundle exec govuk-lint-ruby --diff --cached --format clang bin lib test
+bundle exec rake lint
 
 if [[ -n "$PUBLISH_GEM" ]]; then
   bundle exec rake publish_gem --trace

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task :lint do
+  sh "bundle exec govuk-lint-ruby --diff --cached --format clang bin lib test"
+end


### PR DESCRIPTION
Add a rake task to run the linter in the same way that CI runs it, so you can now just `bundle exec rake lint`.

Also change the default rake task to run tests and then lint, which follows the same pattern used in other repos.