### PR TITLE
[Do Not Merge] Add a search placeholder setter processor

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -36,6 +36,7 @@ module Slimmer
     autoload :SearchIndexSetter, 'slimmer/processors/search_index_setter'
     autoload :SearchPathSetter, 'slimmer/processors/search_path_setter'
     autoload :SearchParameterInserter, 'slimmer/processors/search_parameter_inserter'
+    autoload :SearchPlaceholderSetter, 'slimmer/processors/search_placeholder_setter'
     autoload :SearchRemover, 'slimmer/processors/search_remover'
     autoload :SectionInserter, 'slimmer/processors/section_inserter'
     autoload :TagMover, 'slimmer/processors/tag_mover'

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -14,6 +14,7 @@ module Slimmer
       remove_meta_viewport: "Remove-Meta-Viewport",
       result_count:         "Result-Count",
       search_parameters:    "Search-Parameters",
+      search_placeholder:   "Search-Placeholder",
       section:              "Section",
       skip:                 "Skip",
       template:             "Template",
@@ -31,6 +32,7 @@ module Slimmer
     RESULT_COUNT_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:result_count]}"
     SEARCH_PATH_HEADER = "#{HEADER_PREFIX}-Search-Path"
     SEARCH_PARAMETERS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:search_parameters]}"
+    SEARCH_PLACEHOLDER_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:search_placeholder]}"
     SKIP_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:skip]}"
     TEMPLATE_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:template]}"
     REMOVE_SEARCH_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_search]}"

--- a/lib/slimmer/processors/search_placeholder_setter.rb
+++ b/lib/slimmer/processors/search_placeholder_setter.rb
@@ -1,0 +1,18 @@
+module Slimmer::Processors
+  class SearchPlaceholderSetter
+    def initialize(headers)
+      @headers = headers
+    end
+
+    def filter(_source, template)
+      if placeholder && template.at_css('form#search')
+        template.at_css('form#search label').content = placeholder
+        template.at_css('#site-search-text')['title'] = placeholder
+      end
+    end
+
+    def placeholder
+      @headers[Slimmer::Headers::SEARCH_PLACEHOLDER_HEADER]
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -118,6 +118,7 @@ module Slimmer
         Processors::MetadataInserter.new(response, artefact, options[:app_name]),
         Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
+        Processors::SearchPlaceholderSetter.new(response.headers),
         Processors::RelatedItemsInserter.new(self, artefact),
         Processors::ReportAProblemInserter.new(self,
                                                source_request.url,

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -54,6 +54,11 @@ class HeadersTest < MiniTest::Test
     refute_includes headers.keys, "X-Slimmer-Need-ID"
   end
 
+  def test_should_set_search_placeholder_header
+    set_slimmer_headers search_placeholder: "Search and Destroy"
+    assert_equal "Search and Destroy", headers["X-Slimmer-Search-Placeholder"]
+  end
+
   def test_should_raise_an_exception_if_a_header_has_a_typo
     assert_raises Slimmer::Headers::InvalidHeader do
       set_slimmer_headers seccion: "wrong"

--- a/test/integration/processors/meta_viewport_remover_test.rb
+++ b/test/integration/processors/meta_viewport_remover_test.rb
@@ -1,4 +1,4 @@
-require_relative "../test_helper"
+require "test_helper"
 
 class MetaViewportRemover < SlimmerIntegrationTest
   TEMPLATE = <<-END
@@ -29,11 +29,11 @@ class MetaViewportRemover < SlimmerIntegrationTest
   end
 
   def test_should_not_fail_if_there_is_no_viewport_meta
-    given_response 200, NO_VIEWPORT_TEMPLATE, {Slimmer::Headers::REMOVE_META_VIEWPORT => "true"}
+    given_response 200, NO_VIEWPORT_TEMPLATE, Slimmer::Headers::REMOVE_META_VIEWPORT => "true"
   end
 
   def test_should_remove_the_meta_viewport_if_the_relevant_header_is_set
-    given_response 200, TEMPLATE, {Slimmer::Headers::REMOVE_META_VIEWPORT => "true"}
+    given_response 200, TEMPLATE, Slimmer::Headers::REMOVE_META_VIEWPORT => "true"
     assert_nil Nokogiri::HTML.parse(last_response.body).at_xpath('//head//meta[@name="viewport"]')
   end
 end

--- a/test/integration/processors/metadata_inserter_test.rb
+++ b/test/integration/processors/metadata_inserter_test.rb
@@ -1,7 +1,6 @@
-require_relative "../test_helper"
+require "test_helper"
 
 module MetadataInserterTest
-
   GENERIC_DOCUMENT = <<-END
     <html>
       <head>
@@ -33,7 +32,7 @@ module MetadataInserterTest
 
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
       artefact["details"].merge!(
-        "need_ids" => [100001,100002],
+        "need_ids" => [100001, 100002],
       )
       headers = {
         Slimmer::Headers::FORMAT_HEADER => "custard",
@@ -106,7 +105,7 @@ module MetadataInserterTest
       refute_meta_tag "format"
     end
 
-    def test_should_omit_need_ID
+    def test_should_omit_need_id
       refute_meta_tag "need-ids"
     end
 

--- a/test/integration/processors/search_parameter_inserter_test.rb
+++ b/test/integration/processors/search_parameter_inserter_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
-module SearchPathSetterTest
-
+module SearchParameterInserterTest
   DOCUMENT_WITH_SEARCH = <<-END
     <html>
       <head>
@@ -17,14 +16,14 @@ module SearchPathSetterTest
 
   class WithHeaderTest < SlimmerIntegrationTest
     headers = {
-      "X-Slimmer-Search-Path" => "/specialist/search",
+      "X-Slimmer-Search-Parameters" => '{"filter_organisations": ["land-registry"], "count": 20}',
     }
 
     given_response 200, DOCUMENT_WITH_SEARCH, headers
 
-    def test_should_rewrite_search_action
-      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
-      assert_equal "/specialist/search", search_action
+    def test_should_add_hidden_input
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).css('#search input[type=hidden]')
+      assert_equal %{<input type="hidden" name="filter_organisations[]" value="land-registry"><input type="hidden" name="count" value="20">}, hidden_inputs.to_s
     end
   end
 
@@ -32,8 +31,8 @@ module SearchPathSetterTest
     given_response 200, DOCUMENT_WITH_SEARCH, {}
 
     def test_should_leave_original_search_action
-      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
-      assert_equal "/path/to/search", search_action
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
+      assert_equal nil, hidden_inputs
     end
   end
 end

--- a/test/integration/processors/search_path_setter_test.rb
+++ b/test/integration/processors/search_path_setter_test.rb
@@ -1,7 +1,6 @@
 require "test_helper"
 
-module SearchParameterInserterTest
-
+module SearchPathSetterTest
   DOCUMENT_WITH_SEARCH = <<-END
     <html>
       <head>
@@ -17,14 +16,14 @@ module SearchParameterInserterTest
 
   class WithHeaderTest < SlimmerIntegrationTest
     headers = {
-      "X-Slimmer-Search-Parameters" => '{"filter_organisations": ["land-registry"], "count": 20}',
+      "X-Slimmer-Search-Path" => "/specialist/search",
     }
 
     given_response 200, DOCUMENT_WITH_SEARCH, headers
 
-    def test_should_add_hidden_input
-      hidden_inputs = Nokogiri::HTML.parse(last_response.body).css('#search input[type=hidden]')
-      assert_equal %{<input type="hidden" name="filter_organisations[]" value="land-registry"><input type="hidden" name="count" value="20">}, hidden_inputs.to_s
+    def test_should_rewrite_search_action
+      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
+      assert_equal "/specialist/search", search_action
     end
   end
 
@@ -32,8 +31,8 @@ module SearchParameterInserterTest
     given_response 200, DOCUMENT_WITH_SEARCH, {}
 
     def test_should_leave_original_search_action
-      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
-      assert_equal nil, hidden_inputs
+      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
+      assert_equal "/path/to/search", search_action
     end
   end
 end

--- a/test/integration/processors/search_placeholder_setter_test.rb
+++ b/test/integration/processors/search_placeholder_setter_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class SearchPlaceholderSetterIntegrationTest < SlimmerIntegrationTest
+  TEMPLATE = <<-END
+    <html>
+      <head></head>
+      <body class="body_class">
+        <div id="wrapper">
+          <form id="search" action="/path/to/search">
+            <div class="content">
+              <label for="site-search-text">Search...</label>
+              <input type="search" name="q" id="site-search-text" title="Search...">
+              <input class="submit" type="submit" value="Search">
+            </div>
+          </form>
+        </div>
+      </body>
+    </html>
+    END
+
+  TEMPLATE_WITHOUT_SEARCH = <<-END
+    <html>
+      <head></head>
+      <body class="body_class"></body>
+    </html>
+    END
+
+  def test_should_not_modify_search_placeholder_if_no_header
+    given_response 200, TEMPLATE, {}
+    assert_equal '<label for="site-search-text">Search...</label>',
+      Nokogiri::HTML.parse(last_response.body).at_css('#search label').to_s
+
+    assert_equal '<input type="search" name="q" id="site-search-text" title="Search...">',
+      Nokogiri::HTML.parse(last_response.body).at_css('#site-search-text').to_s
+  end
+
+  def test_should_modify_search_placeholder_to_value_of_header
+    given_response 200, TEMPLATE,
+      'X-Slimmer-Search-Placeholder' => 'Search and Destroy'
+    assert_equal '<label for="site-search-text">Search and Destroy</label>',
+      Nokogiri::HTML.parse(last_response.body).at_css('#search label').to_s
+
+    assert_equal '<input type="search" name="q" id="site-search-text" title="Search and Destroy">',
+      Nokogiri::HTML.parse(last_response.body).at_css('#site-search-text').to_s
+  end
+
+  def test_does_not_error_when_no_search_box_present
+    given_response 200, TEMPLATE_WITHOUT_SEARCH,
+      'X-Slimmer-Search-Placeholder' => 'Search and Destroy'
+  end
+end

--- a/test/processors/search_placeholder_setter_test.rb
+++ b/test/processors/search_placeholder_setter_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class SearchPlaceholderSetterTest < MiniTest::Test
+  def setup
+    super
+    @template = as_nokogiri %{
+      <html>
+      <head>
+      </head>
+      <body class="body_class">
+        <div id="wrapper">
+          <form id="search" action="/path/to/search">
+            <div class="content">
+              <label for="site-search-text">Search...</label>
+              <input type="search" name="q" id="site-search-text" title="Search...">
+              <input class="submit" type="submit" value="Search">
+            </div>
+          </form>
+        </div>
+      </body>
+    </html>
+    }
+  end
+
+  def test_should_rewrite_search_label
+    Slimmer::Processors::SearchPlaceholderSetter.new(
+      Slimmer::Headers::SEARCH_PLACEHOLDER_HEADER => "Search and destroy..."
+    ).filter(nil, @template)
+    assert_in @template, '#search label', 'Search and destroy...'
+  end
+
+  def test_should_rewrite_search_title
+    Slimmer::Processors::SearchPlaceholderSetter.new(
+      Slimmer::Headers::SEARCH_PLACEHOLDER_HEADER => "Search and destroy..."
+    ).filter(nil, @template)
+    assert_equal "Search and destroy...", @template.at_css("#site-search-text")['title']
+  end
+
+  def test_should_not_rewrite_search_label_with_no_header
+    Slimmer::Processors::SearchPlaceholderSetter.new({}).filter(nil, @template)
+    assert_in @template, '#search label', 'Search...'
+  end
+
+  def test_should_not_rewrite_search_title_with_no_header
+    Slimmer::Processors::SearchPlaceholderSetter.new({}).filter(nil, @template)
+    assert_equal "Search...", @template.at_css("#site-search-text")['title']
+  end
+end


### PR DESCRIPTION
This is required for the service manual where we are using Slimmer but need to change the placeholder text within the search box (from "Search" to "Search the service manual").

I am aware that the thing we are changing is actually a _label_, but it functions in approximately the same way as setting the placeholder attribute would, so it seemed more natural to refer to it as a placeholder and ignore the implementation details.