### PR TITLE
[Do not merge] Add breadcrumb meta tag

### DIFF
--- a/lib/slimmer/artefact.rb
+++ b/lib/slimmer/artefact.rb
@@ -26,6 +26,24 @@ class Slimmer::Artefact
     section
   end
 
+  def section
+    title = primary_root_section['title'] || ''
+    if title.empty?
+      '(not set)'
+    else
+      title.tr(' ', '-').downcase
+    end
+  end
+
+  def breadcrumb
+    title = primary_section['title'] || ''
+    if title.empty?
+      '(not set)'
+    else
+      "#{section}>#{title.tr(' ', '-')}".downcase
+    end
+  end
+
   def related_artefacts
     return [] unless self.related
     self.related.map do |r|

--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -10,8 +10,9 @@ module Slimmer::Processors
       head = dest.at_css('head')
 
       if @artefact
-        add_meta_tag('section', @artefact.primary_root_section["title"].downcase, head) if @artefact.primary_root_section
+        add_meta_tag('section', @artefact.section, head) if @artefact.primary_root_section
         add_meta_tag('need-ids', @artefact.need_ids.join(',').downcase, head) if @artefact.need_ids
+        add_meta_tag('breadcrumb', @artefact.breadcrumb, head) if @artefact.primary_root_section && @artefact.primary_section
       end
 
       add_meta_tag('analytics:organisations', @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head)

--- a/test/artefact_test.rb
+++ b/test/artefact_test.rb
@@ -37,6 +37,51 @@ describe Slimmer::Artefact do
     end
   end
 
+  describe "Section and Breadcrumb" do
+    before do
+      @artefact = Slimmer::Artefact.new(artefact_for_slug('business-example'))
+      @section_data = {
+        "id" =>
+          "http://test.gov.uk/tags/section/business%2Fbusiness-tax.json",
+          "content_id" => "b7d6588c-a056-47fc-9528-0b9ff42c3866",
+          "slug" => "business/business-tax",
+          "title" => "Business tax",
+          "details" =>  { "type" => "section" },
+          "state" => "live",
+          "parent" =>  {
+            "id" => "http://test.gov.uk/tags/section/business.json",
+            "slug" => "business",
+            "web_url" => "/browse/business",
+            "title" => "Business and self-employed"
+           }
+         }
+    end
+
+    describe "#section" do
+      it "should return artefact's section" do
+        @artefact.stubs(:primary_section).returns(@section_data)
+        assert_equal "business-and-self-employed", @artefact.section
+      end
+
+      it "should return (not set) as artefact's section if parent section title isn't defined" do
+        @artefact.stubs(:primary_section).returns({})
+        assert_equal "(not set)", @artefact.section
+      end
+    end
+
+    describe "#breadcrumb" do
+      it "should return artefact's breadcrumb" do
+        @artefact.stubs(:primary_section).returns(@section_data)
+        assert_equal "business-and-self-employed>business-tax", @artefact.breadcrumb
+      end
+
+      it "should return (not set) as artefact's breadcrumb if child section title isn't defined" do
+        @artefact.stubs(:primary_section).returns({})
+        assert_equal "(not set)", @artefact.breadcrumb
+      end
+    end
+  end
+
   describe "Primary root section" do
     before do
       @artefact = Slimmer::Artefact.new(artefact_for_slug('something'))
@@ -73,7 +118,7 @@ describe Slimmer::Artefact do
     before do
       @data = artefact_for_slug('something')
     end
-    
+
     it "should return an array of corresponding artefact instances" do
       @data["related"] << artefact_for_slug('vat')
       @data["related"] << artefact_for_slug('something-else')

--- a/test/processors/metadata_inserter_test.rb
+++ b/test/processors/metadata_inserter_test.rb
@@ -50,6 +50,10 @@ module MetadataInserterTest
       assert_meta_tag "section", "rhubarb"
     end
 
+    def test_should_include_breadcrumb_meta_tag
+      assert_meta_tag "breadcrumb", "rhubarb>in-puddings"
+    end
+
     def test_should_include_format_meta_tag
       assert_meta_tag "format", "custard"
     end
@@ -89,6 +93,7 @@ module MetadataInserterTest
       refute_meta_tag "need-ids"
       # the presence of these attributes tests that the nil check worked
       assert_meta_tag "section", "rhubarb"
+      assert_meta_tag "breadcrumb", "rhubarb>in-puddings"
       assert_meta_tag "format", "custard"
     end
   end
@@ -100,6 +105,10 @@ module MetadataInserterTest
 
     def test_should_omit_section
       refute_meta_tag "section"
+    end
+
+    def test_should_omit_breadcrumb
+      refute_meta_tag "breadcrumb"
     end
 
     def test_should_omit_internal_format_name


### PR DESCRIPTION
Related to https://github.com/alphagov/static/pull/837

This commit updates the list of existing meta tags with one for breadcrumb.

This holds the current breadcrumb per published page.

This commit also defines a section and breadcrumb method that returns the
parent and child section respectively or "(not set)" if empty or not defined.

if define and spaces exist, it will be replaced with a dash (-).

This is being implemented upon request from the performance analyst.

This will assist with the production of Alpha reports, based on topic and page
performance.