### PR TITLE
Add an ‘inside header’ inserter

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -29,6 +29,7 @@ module Slimmer
     autoload :FooterRemover, 'slimmer/processors/footer_remover'
     autoload :MetadataInserter, 'slimmer/processors/metadata_inserter'
     autoload :HeaderContextInserter, 'slimmer/processors/header_context_inserter'
+    autoload :InsideHeaderInserter, 'slimmer/processors/inside_header_inserter'
     autoload :NavigationMover, 'slimmer/processors/navigation_mover'
     autoload :RelatedItemsInserter, 'slimmer/processors/related_items_inserter'
     autoload :ReportAProblemInserter, 'slimmer/processors/report_a_problem_inserter'

--- a/lib/slimmer/processors/inside_header_inserter.rb
+++ b/lib/slimmer/processors/inside_header_inserter.rb
@@ -1,0 +1,11 @@
+module Slimmer::Processors
+  class InsideHeaderInserter
+    def filter(src, dest)
+      insertion = src.at_css('.slimmer-inside-header')
+
+      if insertion
+        dest.at_css('.header-logo').add_next_sibling(insertion.inner_html)
+      end
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -113,6 +113,7 @@ module Slimmer
         Processors::ConditionalCommentMover.new(),
         Processors::BodyInserter.new(wrapper_id),
         Processors::BodyClassCopier.new,
+        Processors::InsideHeaderInserter.new,
         Processors::HeaderContextInserter.new(),
         Processors::SectionInserter.new(artefact),
         Processors::MetadataInserter.new(response, artefact, options[:app_name]),

--- a/test/processors/inside_header_inserter_test.rb
+++ b/test/processors/inside_header_inserter_test.rb
@@ -1,0 +1,35 @@
+require_relative '../test_helper'
+
+class InsideHeaderInserterTest < MiniTest::Test
+  def test_should_insert_into_header
+    source = as_nokogiri %{
+      <html>
+        <body>
+          <div class="slimmer-inside-header">
+            <h2>Inserted Page Title</h2>
+          </div>
+        </body>
+      </html>
+    }
+    template = as_nokogiri %{
+      <html>
+        <body>
+          <div class="header-global">
+            <div class="header-logo">
+              <a href="https://www.gov.uk/" title="Go to the GOV.UK homepage" id="logo" class="content">
+                <img src="/assets/gov.uk_logotype_crown_invert_trans.png" width="35" height="31" alt="">
+              </a>
+            </div>
+          </div>
+        </body>
+      </html>
+    }
+
+    Slimmer::Processors::InsideHeaderInserter.new.filter(source, template)
+
+    assert_in template,
+      "div.header-global .header-logo + h2",
+      "Inserted Page Title",
+      'Expecting the H2 to be inserted after .header-logo'
+  end
+end


### PR DESCRIPTION
This processor allows an application to inject a block of HTML after the logo by including a `.inside-header` element in their application’s output.

This is effectively like adding content to the inside_header yield block in govuk_template.

The service manual is using this to insert a title into the header.