### PR TITLE
Remove need IDs meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Removes the need_id meta tag, which is no longer used.
+
 # 9.6.0
 
 * Adds an 'inside header inserter' processor which allows an application to
@@ -19,7 +23,7 @@
 
 * Adds an RSpec helper that makes it easy for host applications to
   configure Slimmer correctly under test.
-  
+
   Fixes `stub_shared_component_locales` helper to correctly stub HTTP
   requests to fetch locale information when rendering its templates.
 

--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -11,7 +11,6 @@ module Slimmer::Processors
 
       if @artefact
         add_meta_tag('section', @artefact.primary_root_section["title"].downcase, head) if @artefact.primary_root_section
-        add_meta_tag('need-ids', @artefact.need_ids.join(',').downcase, head) if @artefact.need_ids
       end
 
       add_meta_tag('analytics:organisations', @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head)

--- a/test/artefact_test.rb
+++ b/test/artefact_test.rb
@@ -73,7 +73,7 @@ describe Slimmer::Artefact do
     before do
       @data = artefact_for_slug('something')
     end
-    
+
     it "should return an array of corresponding artefact instances" do
       @data["related"] << artefact_for_slug('vat')
       @data["related"] << artefact_for_slug('something-else')
@@ -103,7 +103,6 @@ describe Slimmer::Artefact do
 
     it "should return the corresponding field from details if it doesn't exist at the top level" do
       @data["details"]["foo"] = "baz"
-      assert_equal @data["details"]["need_id"], @a.need_id
       assert_equal "bar", @a.foo
     end
 

--- a/test/headers_test.rb
+++ b/test/headers_test.rb
@@ -49,11 +49,6 @@ class HeadersTest < MiniTest::Test
     assert_equal "rhubarb", headers["X-Slimmer-Skip"]
   end
 
-  def test_should_skip_missing_headers
-    set_slimmer_headers section: "rhubarb"
-    refute_includes headers.keys, "X-Slimmer-Need-ID"
-  end
-
   def test_should_raise_an_exception_if_a_header_has_a_typo
     assert_raises Slimmer::Headers::InvalidHeader do
       set_slimmer_headers seccion: "wrong"

--- a/test/processors/metadata_inserter_test.rb
+++ b/test/processors/metadata_inserter_test.rb
@@ -32,9 +32,6 @@ module MetadataInserterTest
       super
 
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
-      artefact["details"].merge!(
-        "need_ids" => [100001,100002],
-      )
       headers = {
         Slimmer::Headers::FORMAT_HEADER => "custard",
         Slimmer::Headers::RESULT_COUNT_HEADER => "3",
@@ -54,10 +51,6 @@ module MetadataInserterTest
       assert_meta_tag "format", "custard"
     end
 
-    def test_should_include_need_ids_meta_tag
-      assert_meta_tag "need-ids", "100001,100002"
-    end
-
     def test_should_include_organisations_meta_tag
       assert_meta_tag "analytics:organisations", "<P1><D422>"
     end
@@ -68,28 +61,6 @@ module MetadataInserterTest
 
     def test_should_include_search_result_count_meta_tag
       assert_meta_tag "search-result-count", "3"
-    end
-  end
-
-  class WithInvalidAttributes < SlimmerIntegrationTest
-    include MetaTagAssertions
-
-    def setup
-      super
-    end
-
-    def test_should_skip_passing_need_ids_if_they_are_nil
-      artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
-      headers = {
-        Slimmer::Headers::ARTEFACT_HEADER => artefact.to_json,
-        Slimmer::Headers::FORMAT_HEADER => "custard"
-      }
-      given_response 200, GENERIC_DOCUMENT, headers
-
-      refute_meta_tag "need-ids"
-      # the presence of these attributes tests that the nil check worked
-      assert_meta_tag "section", "rhubarb"
-      assert_meta_tag "format", "custard"
     end
   end
 
@@ -104,10 +75,6 @@ module MetadataInserterTest
 
     def test_should_omit_internal_format_name
       refute_meta_tag "format"
-    end
-
-    def test_should_omit_need_ID
-      refute_meta_tag "need-ids"
     end
 
     def test_should_omit_organisations
@@ -130,9 +97,6 @@ module MetadataInserterTest
       super
 
       artefact = artefact_for_slug_in_a_subsection("something", "rhubarb/in-puddings")
-      artefact["details"].merge!(
-        "need_ids" => [100001, 100002],
-      )
       headers = {
         Slimmer::Headers::RESULT_COUNT_HEADER => "3",
         Slimmer::Headers::ARTEFACT_HEADER => artefact.to_json,


### PR DESCRIPTION
This commit removes the need IDs meta tag. The performance analysts confirmed at a meeting on 12/10/2016 that this tag is no longer required.

https://trello.com/c/WUiqJuh6/188-remove-govuk-need-ids-meta-tag