### PR TITLE
Rename SharedTemplates to GovukComponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   metatags.
 * Drop support for old Rails & Ruby versions. This gem now supports Rails 4.2 and 5.X
   on Ruby 2.1 and 2.2.
+* Renames `Slimmer::SharedTemplates` to `Slimmer::GovukComponents`
 
 # 9.6.0
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To get asset tag helpers to point to your external asset server, add
 ```rb
 config.action_controller.asset_host = "http://my.alternative.host"
 ```
-    
+
 to `application.rb`.
 
 ## Specifying a template
@@ -101,25 +101,25 @@ YourApp::Application.configure do
 end
 ```
 
-## Shared components
+## GOV.UK Components
 
-To use shared template components you need to include the shared template resolver
+To use [shared template components](https://govuk-component-guide.herokuapp.com/) you need to include the GOV.UK component module:
 
 ```rb
 class ApplicationController < ActionController::Base
-  include Slimmer::SharedTemplates
+  include Slimmer::GovukComponents
 end
 ```
 
-This will make calls out to static when you try and render a partial prefixed with `govuk-component`:
+This will make calls out to static when you try and render a partial prefixed with `govuk_component`:
 
 ```erb
-<%= render partial: 'govuk-component/example_component' %>
+<%= render partial: 'govuk_component/example_component' %>
 ```
 
 You will need a copy of static running for the templates to be loaded from.
 
-### Testing shared components
+### Testing components
 
 In test mode (when `Rails.env.test?` returns `true`), shared components are not
 fetched from Static. Instead they are rendered as a dummy tag which contains a
@@ -130,8 +130,8 @@ component to assert that it was used. You can make it available in your tests
 with:
 
 ```rb
-require 'slimmer/test_helpers/shared_templates'
-include Slimmer::TestHelpers::SharedTemplates
+require 'slimmer/test_helpers/govuk_components'
+include Slimmer::TestHelpers::GovukComponents
 ```
 
 And then assert that the component has been used:

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -17,7 +17,7 @@ module Slimmer
   autoload :App, 'slimmer/app'
   autoload :Headers, 'slimmer/headers'
 
-  autoload :SharedTemplates, 'slimmer/shared_templates'
+  autoload :GovukComponents, 'slimmer/govuk_components'
   autoload :ComponentResolver, 'slimmer/component_resolver'
   autoload :I18nBackend, 'slimmer/i18n_backend'
 

--- a/lib/slimmer/cucumber.rb
+++ b/lib/slimmer/cucumber.rb
@@ -1,9 +1,9 @@
 require 'cucumber'
 
 require 'slimmer/test'
-require 'slimmer/test_helpers/shared_templates'
+require 'slimmer/test_helpers/govuk_components'
 
-World(Slimmer::TestHelpers::SharedTemplates)
+World(Slimmer::TestHelpers::GovukComponents)
 
 Before do
   stub_shared_component_locales

--- a/lib/slimmer/govuk_components.rb
+++ b/lib/slimmer/govuk_components.rb
@@ -1,10 +1,10 @@
 module Slimmer
-  module SharedTemplates
+  module GovukComponents
     def self.included into
-      into.before_action :add_shared_templates
+      into.before_action :add_govuk_components
     end
 
-    def add_shared_templates
+    def add_govuk_components
       append_view_path Slimmer::ComponentResolver.new
 
       return if slimmer_backend_included?

--- a/lib/slimmer/rspec.rb
+++ b/lib/slimmer/rspec.rb
@@ -2,10 +2,10 @@ require 'rspec/core'
 
 require 'slimmer'
 require 'slimmer/test'
-require 'slimmer/test_helpers/shared_templates'
+require 'slimmer/test_helpers/govuk_components'
 
 RSpec.configure do |config|
-  config.include Slimmer::TestHelpers::SharedTemplates
+  config.include Slimmer::TestHelpers::GovukComponents
 
   config.before { stub_shared_component_locales }
 end

--- a/lib/slimmer/test_helpers/govuk_components.rb
+++ b/lib/slimmer/test_helpers/govuk_components.rb
@@ -2,7 +2,7 @@ require 'webmock'
 
 module Slimmer
   module TestHelpers
-    module SharedTemplates
+    module GovukComponents
       def stub_shared_component_locales
         stub_request(:get, /https?:\/\/\S+.gov.uk\/templates\/locales\/.+/).
           to_return(status: 400, headers: {})

--- a/test/test_helpers/govuk_components_test.rb
+++ b/test/test_helpers/govuk_components_test.rb
@@ -1,17 +1,17 @@
 require_relative "../test_helper"
-require_relative "../../lib/slimmer/test_helpers/shared_templates"
+require_relative "../../lib/slimmer/test_helpers/govuk_components"
 
-describe Slimmer::TestHelpers::SharedTemplates do
-
+describe Slimmer::TestHelpers::GovukComponents do
   let(:subject) {
     class Dummy
-      include Slimmer::TestHelpers::SharedTemplates
+      include Slimmer::TestHelpers::GovukComponents
     end
-    }
+  }
 
-  describe 'shared_component_selector' do
-    it 'should generate a selector for components' do
+  describe '#shared_component_selector' do
+    it 'generates a selector for components' do
       outcome = subject.new.shared_component_selector('flux_capacitor')
+
       expected = "test-govuk-component[data-template='govuk_component-flux_capacitor']"
       assert_equal expected, outcome
     end


### PR DESCRIPTION
We're updating slimmer across a lot of apps with breaking changes, so I thought to rename a few things for consistency while we're upgrading things.

We're already calling this functionality "GOV.UK components" in most places. For consistency this renames the modules that we include into the controller and tests.

## Before

```ruby
class ApplicationController < ActionController::Base
  include Slimmer::SharedTemplates
end
```

## After

```ruby
class ApplicationController < ActionController::Base
  include Slimmer::GovukComponents
end
```

Closes https://github.com/alphagov/slimmer/issues/169.

After merge:

- [ ] http://govuk-component-guide.herokuapp.com/about

