### PR TITLE
Drop testing for Rails 3.2, 4.1, Ruby 1.9.3 and 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Removes the need_id meta tag, which is no longer used.
 * Removes the functionality for breadcrumbs, related links and artefact-powered
   metatags.
+* Drop support for old Rails & Ruby versions. This gem now supports Rails 4.2 and 5.X
+  on Ruby 2.1 and 2.2.
 
 # 9.6.0
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -26,18 +26,6 @@ test 5.0.x 2.2
 
 test 4.2.x 2.3
 test 4.2.x 2.2
-test 4.2.x 2.1
-test 4.2.x 1.9.3
-
-test 4.1.x 2.3
-test 4.1.x 2.2
-test 4.1.x 2.1
-test 4.1.x 1.9.3
-
-test 3.2.x 2.3
-test 3.2.x 2.2
-test 3.2.x 2.1
-test 3.2.x 1.9.3
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
 bundle exec rake lint


### PR DESCRIPTION
Because:

- We have only one app running 3.X (design-principles, which will be removed in the future)
- There are no apps using slimmer that run Rails 4.1
- No apps that run 1.9.3 or 2.1

Source:

https://docs.google.com/spreadsheets/d/1FJmr39c9eXgpA-qHUU6GAbbJrnenc0P7JcyY2NB9PgU/edit#gid=1480786499