### PR TITLE
Remove old testing Gemfiles

### DIFF
--- a/gemfiles/Gemfile.rails-3.2.x
+++ b/gemfiles/Gemfile.rails-3.2.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 3.2.0'
-gem 'rest-client', '~> 1.0', platforms: :ruby_19
-
-gemspec :path => '../'

--- a/gemfiles/Gemfile.rails-4.1.x
+++ b/gemfiles/Gemfile.rails-4.1.x
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'rails', '~> 4.1.0'
-gem 'rest-client', '~> 1.0', platforms: :ruby_19
-
-gemspec :path => '../'


### PR DESCRIPTION
Support for these versions was dropped in https://github.com/alphagov/slimmer/pull/174.