### PR TITLE
Release Slimmer 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 10.0.0
 
 * Removes the need_id meta tag, which is no longer used.
 * Removes the functionality for breadcrumbs, related links and artefact-powered

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '9.6.0'
+  VERSION = '10.0.0'
 end


### PR DESCRIPTION
This anniversary edition of slimmer:

* Removes the need_id meta tag, which is no longer used.
* Removes the functionality for breadcrumbs, related links and artefact-powered metatags.
* Drop support for old Rails & Ruby versions. This gem now supports Rails 4.2 and 5.X on Ruby 2.1 and 2.2.
* Renames `Slimmer::SharedTemplates` to `Slimmer::GovukComponents`