### PR TITLE
Remove test files from the built gem

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'rest-client'
   s.add_dependency 'activesupport'
 
-  s.test_files    = Dir['test/**/*']
   s.add_development_dependency 'minitest', '~> 5.4'
   s.add_development_dependency 'rake', '~> 0.9.2.2'
   s.add_development_dependency 'rack-test', '~> 0.6.1'
@@ -34,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
   s.add_development_dependency 'govuk-lint', '~> 0.5.1'
-  s.files         = Dir[
+  s.files = Dir[
     'README.md',
     'CHANGELOG.md',
     'lib/**/*',


### PR DESCRIPTION
When the test/spec directory is mentioned on the gemspec it actually
bundles the gem with those files.

There's also no reason to send the test files to production.

### Before

<img width="395" alt="screen shot 2016-12-16 at 11 25 23" src="https://cloud.githubusercontent.com/assets/136777/21261434/494391d0-c383-11e6-9dd3-16c4c8f7508a.png">

### After

<img width="385" alt="screen shot 2016-12-16 at 11 26 57" src="https://cloud.githubusercontent.com/assets/136777/21261433/493daa4a-c383-11e6-9f6b-aaa0f0761cc1.png">

