### PR TITLE
Add support for Airbrake 5

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -88,9 +88,7 @@ module Slimmer
           p.filter(src,dest)
         rescue => e
           logger.error "Slimmer: Failed while processing #{p}: #{[ e.message, e.backtrace ].flatten.join("\n")}"
-          if defined?(Airbrake)
-            Airbrake.notify_or_ignore(e, rack_env: rack_env)
-          end
+          notify_airbrake(e, rack_env: rack_env)
           raise if strict
         end
         processor_end_time = Time.now
@@ -133,6 +131,20 @@ module Slimmer
         Processors::TitleInserter.new()
       ]
       process(processors, body, template(template_name), rack_env)
+    end
+
+  private
+
+    def notify_airbrake(*args)
+      return unless defined?(Airbrake)
+
+      if Airbrake.respond_to?(:notify_or_ignore)
+        # Airbrake < 5 uses a method called "notify_or_ignore"
+        Airbrake.notify_or_ignore(*args)
+      elsif Airbrake.respond_to?(:notify)
+        # Airbrake >= 5 deprecates "notify_or_ignore", so use "notify" instead
+        Airbrake.notify(*args)
+      end
     end
   end
 end


### PR DESCRIPTION
At the moment, Slimmer attempts to call Airbrake.notify_or_ignore when
processing fails. The `notify_or_ignore` method was removed in Airbrake
5, which means that this fails in applications which use Slimmer and
Airbrake 5, which is most Rails 5 applications.

This adds a slightly more defensive check when attempting to notify
Airbrake, by confirming that `Airbrake` responds to `notify_or_ignore`.
If it doesn't, it checks to see if it responds to `notify`, and will
use that. If neither exist, it does nothing, as before.