### PR TITLE
Force request url to be UTF-8 encoding

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -105,6 +105,12 @@ module Slimmer
 
     def success(source_request, response, body)
       wrapper_id = options[:wrapper_id] || 'wrapper'
+
+      # The variables set in the source request might not be encoded as UTF-8,
+      # Unicorn, for instance, will set them to be ASCII. This shouldn't matter
+      # normally because URI's should have UTF-8 characters percent encoded,
+      # but not all agents follow this.
+      request_url = source_request.url.force_encoding(Encoding::UTF_8)
       processors = [
         Processors::TitleInserter.new(),
         Processors::TagMover.new(),
@@ -118,7 +124,7 @@ module Slimmer
         Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
         Processors::ReportAProblemInserter.new(self,
-                                               source_request.url,
+                                               request_url,
                                                response.headers,
                                                wrapper_id),
         Processors::SearchRemover.new(response.headers),

--- a/test/processors/search_parameter_inserter_test.rb
+++ b/test/processors/search_parameter_inserter_test.rb
@@ -33,7 +33,7 @@ module SearchParameterInserterTest
 
     def test_should_leave_original_search_action
       hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
-      assert_equal nil, hidden_inputs
+      assert_nil hidden_inputs
     end
   end
 end


### PR DESCRIPTION
This small change is the result of a long and complicated hunt into a
mysterious bug that was occurring approximately 4000 times a day on
Whitehall.

It is possible that GOV.UK may receive requests that have Unicode
characters in them. These are invalid as URIs as Unicode character must
be percent escaped. However unlike github - which will reject Unicode
characters with a 400 Bad Request - we will accept them.

This leaves is somewhat undefined waters where ruby servers may differ
in how they handle the request. Unicorn converts the request into an
ASCII encoded string. Normally this isn't a problem unless this string
contains a character outside of the range compatible with Unicode.

When this does occur though it raises an error when this string is
concatenated with the UTF-8 template. This can be resolved by forcing
the encoding to UTF-8.

This is done here as this will resolve this issue across all apps that
use Slimmer.

Alternatively this could be fixed in Whitehall by adding something like
this to Rack: https://github.com/whitequark/rack-utf8_sanitizer

This also isn't testable with an integration test as rack won't allow integration tests to have UTF-8 characters in them. I'm going to check whether I can make crawler play ball more nicely too.

/cc @gpeng 