### PR TITLE
Add a user agent header for all requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Use `Rails.cache` as the cache for templates, locales and components
+* Add a `User-Agent` header to all outgoing API requests
 
 # 10.0.0
 

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -25,6 +25,7 @@ module Slimmer
   autoload :Template, 'slimmer/template'
   autoload :App, 'slimmer/app'
   autoload :Headers, 'slimmer/headers'
+  autoload :HTTPClient, 'slimmer/http_client'
 
   autoload :GovukComponents, 'slimmer/govuk_components'
   autoload :ComponentResolver, 'slimmer/component_resolver'

--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -42,10 +42,7 @@ module Slimmer
     end
 
     def fetch(template_url)
-      headers = {}
-      headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
-      response = RestClient.get(template_url, headers)
-      response.body
+      HTTPClient.get(template_url)
     rescue RestClient::Exception => e
       raise TemplateNotFoundException, "Unable to fetch: '#{template_url}' because #{e}", caller
     rescue Errno::ECONNREFUSED => e

--- a/lib/slimmer/govuk_request_id.rb
+++ b/lib/slimmer/govuk_request_id.rb
@@ -1,10 +1,6 @@
 module Slimmer
   class GovukRequestId
     class << self
-      def set?
-        !(value.nil? || value.empty?)
-      end
-
       def value
         Thread.current[:slimmer_govuk_request_id]
       end
@@ -15,4 +11,3 @@ module Slimmer
     end
   end
 end
-

--- a/lib/slimmer/http_client.rb
+++ b/lib/slimmer/http_client.rb
@@ -1,8 +1,10 @@
 module Slimmer
   class HTTPClient
     def self.get(url)
-      headers = {}
-      headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
+      headers = {
+        govuk_request_id: GovukRequestId.value,
+      }
+
       response = RestClient.get(url, headers)
       response.body
     end

--- a/lib/slimmer/http_client.rb
+++ b/lib/slimmer/http_client.rb
@@ -1,7 +1,11 @@
+require "slimmer/govuk_request_id"
+require "restclient"
+
 module Slimmer
   class HTTPClient
     def self.get(url)
       headers = {
+        user_agent: "slimmer/#{Slimmer::VERSION} (#{ENV['GOVUK_APP_NAME']})",
         govuk_request_id: GovukRequestId.value,
       }
 

--- a/lib/slimmer/http_client.rb
+++ b/lib/slimmer/http_client.rb
@@ -1,0 +1,10 @@
+module Slimmer
+  class HTTPClient
+    def self.get(url)
+      headers = {}
+      headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
+      response = RestClient.get(url, headers)
+      response.body
+    end
+  end
+end

--- a/lib/slimmer/i18n_backend.rb
+++ b/lib/slimmer/i18n_backend.rb
@@ -43,10 +43,7 @@ module Slimmer
     end
 
     def fetch(url)
-      headers = {}
-      headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
-      response = RestClient.get(url, headers)
-      response.body
+      HTTPClient.get(url)
     rescue RestClient::Exception => e
       raise TemplateNotFoundException, "Unable to fetch: '#{url}' because #{e}", caller
     rescue Errno::ECONNREFUSED => e

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -21,10 +21,7 @@ module Slimmer
 
     def load_template(template_name)
       url = template_url(template_name)
-      headers = {}
-      headers[:govuk_request_id] = GovukRequestId.value if GovukRequestId.set?
-      response = RestClient.get(url, headers)
-      response.body
+      HTTPClient.get(url)
     rescue RestClient::Exception => e
       raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     rescue Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError => e

--- a/test/http_client_test.rb
+++ b/test/http_client_test.rb
@@ -1,0 +1,17 @@
+require_relative "test_helper"
+
+describe Slimmer::HTTPClient do
+  describe ".get" do
+    it "adds the correct user agent header" do
+      ENV['GOVUK_APP_NAME'] = 'my-app'
+
+      request = stub_request(:get, "https://example.com/").
+        with(headers: { 'User-Agent' => 'slimmer/10.0.0 (my-app)' }).
+        to_return(status: 200)
+
+      Slimmer::HTTPClient.get("https://example.com")
+
+      assert_requested(request)
+    end
+  end
+end

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -15,30 +15,18 @@ describe Slimmer::Skin do
       assert_equal "<foo />", template
     end
 
-    describe "should pass the GOVUK-Request-Id header when requesting the template" do
-      before do
+    describe "passes the GOVUK-Request-Id header when requesting the template" do
+      it "passes the value from the original request if set" do
         @skin = Slimmer::Skin.new asset_host: "http://example.local/"
 
         @expected_url = "http://example.local/templates/example.html.erb"
         stub_request(:get, @expected_url).to_return :body => "<foo />"
-      end
 
-      it "should pass the value from the original request if set" do
         Slimmer::GovukRequestId.value = '12345'
         template = @skin.template('example')
 
         assert_requested :get, @expected_url do |request|
           request.headers['Govuk-Request-Id'] == '12345'
-        end
-        assert_equal "<foo />", template
-      end
-
-      it "shouldnot set the header if the value is not set" do
-        Slimmer::GovukRequestId.value = ''
-        template = @skin.template('example')
-
-        assert_requested :get, @expected_url do |request|
-          ! request.headers.has_key?('Govuk-Request-Id')
         end
         assert_equal "<foo />", template
       end


### PR DESCRIPTION
Related to https://github.com/alphagov/slimmer/pull/183, this adds a `User-Agent` header to all requests to `static`, just like gds-api-adapters does. This will make it easier for us to see where requests come from.

https://trello.com/c/D9HmkJwI