### PR TITLE
Release 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 10.1.0
+
 * Use `Rails.cache` as the cache for templates, locales and components
 * Add a `User-Agent` header to all outgoing API requests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 10.1.0
 
-* Use `Rails.cache` as the cache for templates, locales and components
+* Use `Rails.cache` as the cache for templates, locales and components. You can
+  remove `config.slimmer.use_cache` for your application, as you can no longer
+  opt-out of caching.
 * Add a `User-Agent` header to all outgoing API requests
 
 # 10.0.0

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '10.0.0'
+  VERSION = '10.1.0'
 end

--- a/test/http_client_test.rb
+++ b/test/http_client_test.rb
@@ -6,7 +6,7 @@ describe Slimmer::HTTPClient do
       ENV['GOVUK_APP_NAME'] = 'my-app'
 
       request = stub_request(:get, "https://example.com/").
-        with(headers: { 'User-Agent' => 'slimmer/10.0.0 (my-app)' }).
+        with(headers: { 'User-Agent' => "slimmer/#{Slimmer::VERSION} (my-app)" }).
         to_return(status: 200)
 
       Slimmer::HTTPClient.get("https://example.com")


### PR DESCRIPTION
Improves caching and adds user agent to outgoing requests. Be sure to remove the `slimmer.use_cache` config from your initialiser.