### PR TITLE
[Don't merge] Plug memory leak in components

### DIFF
--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -5,12 +5,6 @@ module Slimmer
   class ComponentResolver < ::ActionView::Resolver
     TEST_TAG_NAME = 'test-govuk-component'
 
-    def self.caching
-      # this turns off the default ActionView::Resolver caching which caches
-      # all templates for the duration of the current process in production
-      false
-    end
-
     def find_templates(name, prefix, partial, details, outside_app_allowed = false)
       return [] unless prefix == 'govuk_component'
 

--- a/lib/slimmer/govuk_components.rb
+++ b/lib/slimmer/govuk_components.rb
@@ -13,12 +13,11 @@ module Slimmer
   module GovukComponents
     def self.included into
       into.before_action :add_govuk_components
+      into.append_view_path Slimmer::ComponentResolver.new
     end
 
     # @private
     def add_govuk_components
-      append_view_path Slimmer::ComponentResolver.new
-
       return if slimmer_backend_included?
       I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
     end


### PR DESCRIPTION
All our frontend apps leak memory:

<img width="1419" alt="screen shot 2017-02-23 at 15 52 30" src="https://cloud.githubusercontent.com/assets/233676/23266590/1f7c3594-f9e0-11e6-8d5d-c48d36985ca9.png">

https://grafana.publishing.service.gov.uk/dashboard/db/memory-dashboard

I think the cause of this is the `GovukComponent` class. It currently instantiates a `ComponentResolver` class per request. By instantiating the resolver only once (when the controller is loaded), we seem to saving a lot of memory.

To test I've used the [derailed_benchmarks gem][derailed]. I've tested this with the following command on `government-frontend`:

[derailed]: https://github.com/schneems/derailed_benchmarks

```
GOVUK_APP_DOMAIN=www.gov.uk GOVUK_ASSET_ROOT=https://www.gov.uk GOVUK_WEBSITE_ROOT=https://www.gov.uk PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk DERAILED_SKIP_ACTIVE_RECORD=true TEST_COUNT=100 PATH_TO_HIT=/government/case-studies/nda-archive SLIMMER_DEV=1 bundle exec derailed exec perf:objects
```

This makes a 100 requests to the app and outputs stats on memory usage.

Before this change (master):

```
Total allocated: 159341340 bytes (1415052 objects)
Total retained:  680097 bytes (5510 objects)
```

After this change:

```
Total allocated: 112137848 bytes (997652 objects)
Total retained:  146971 bytes (613 objects)
```

Derailed can also show memory over time (using `derailed exec perf:mem_over_time`). The following is a graph of the `multipage-frontend` running at full speed over 10-15 minute period.

<img width="894" alt="screen shot 2017-02-23 at 15 59 09" src="https://cloud.githubusercontent.com/assets/233676/23266911/12007ba4-f9e1-11e6-9ba5-cefff4662907.png">

And `government-frontend`:

<img width="905" alt="screen shot 2017-02-23 at 16 00 15" src="https://cloud.githubusercontent.com/assets/233676/23266950/31ae45bc-f9e1-11e6-874e-718284ea68cd.png">

## Don't merge

This can't be merged, because we actually rely on the per-request model. This is what makes it possible to make changes to `static` and getting them picked up by all frontend apps. 

I'd welcome some thoughts about a solution. It seems we can make the frontends a lot faster by caching more in memory, but the trade-off would be that we have to restart those applications after `static` deploys.

Special thanks to @h-lame for the help during this quest.

cc @boffbowsh @tomnatt @gpeng @timblair @nickcolley 