### PR TITLE
Bump to 10.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.1.2
+
+* Bugfix for request URI's encoded as ASCII
+
 # 10.1.1
 
 * Bugfix for caching behaviour

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '10.1.1'
+  VERSION = '10.1.2'
 end


### PR DESCRIPTION
Bugfix for request URI's encoded as ASCII