### PR TITLE
Fix memory leak in components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fix memory leak in components
+
 # 10.1.2
 
 * Bugfix for request URI's encoded as ASCII

--- a/lib/slimmer/component_resolver.rb
+++ b/lib/slimmer/component_resolver.rb
@@ -5,12 +5,6 @@ module Slimmer
   class ComponentResolver < ::ActionView::Resolver
     TEST_TAG_NAME = 'test-govuk-component'
 
-    def self.caching
-      # this turns off the default ActionView::Resolver caching which caches
-      # all templates for the duration of the current process in production
-      false
-    end
-
     def find_templates(name, prefix, partial, details, outside_app_allowed = false)
       return [] unless prefix == 'govuk_component'
 

--- a/lib/slimmer/govuk_components.rb
+++ b/lib/slimmer/govuk_components.rb
@@ -17,10 +17,15 @@ module Slimmer
 
     # @private
     def add_govuk_components
-      append_view_path Slimmer::ComponentResolver.new
+      append_view_path GovukComponents.expiring_resolver_cache.resolver
 
       return if slimmer_backend_included?
       I18n.backend = I18n::Backend::Chain.new(I18n.backend, Slimmer::I18nBackend.new)
+    end
+
+    # @private
+    def self.expiring_resolver_cache
+      @expiring_resolver_cache ||= TimedExpirationResolverCache.new
     end
 
   private
@@ -28,6 +33,25 @@ module Slimmer
     def slimmer_backend_included?
       I18n.backend.is_a?(I18n::Backend::Chain) &&
         I18n.backend.backends.any? { |b| b.is_a? Slimmer::I18nBackend }
+    end
+
+    # Slimmer::ComponentResolver instantiates a lot of large objects and leaks
+    # memory. This class will cache the resolver so that it doesn't have to
+    # create new ActionView::Template objects for each request. The cache is
+    # timed to allow frontends to pick up changes made to components in `static`.
+    class TimedExpirationResolverCache
+      def initialize
+        @cache_last_reset = Time.now
+      end
+
+      def resolver
+        if (@cache_last_reset + Slimmer::CACHE_TTL) < Time.now
+          @resolver = nil
+          @cache_last_reset = Time.now
+        end
+
+        @resolver ||= Slimmer::ComponentResolver.new
+      end
     end
   end
 end


### PR DESCRIPTION
Most of our frontend apps leak memory, which causes regular Icinga alerts for 2nd line. We currently mitigate this by restarting the apps manually.

This dashboard shows the problem: https://grafana.publishing.service.gov.uk/dashboard/db/memory-dashboard

<img width="1303" alt="screen shot 2017-02-27 at 12 13 15" src="https://cloud.githubusercontent.com/assets/233676/23360966/1bddeeba-fce6-11e6-91a5-ce05ccb36277.png">


The primary cause of this seems to be the `GovukComponent` class. This currently instantiates a `ComponentResolver` class per request, which in turn instantiates lots of ActionView related objects.

By caching the resolver for 15 minutes, we save a lot of memory.

To test I've used the [derailed_benchmarks gem][derailed]. I've tested this with the following command on `government-frontend`:

[derailed]: https://github.com/schneems/derailed_benchmarks

```
GOVUK_APP_DOMAIN=www.gov.uk GOVUK_ASSET_ROOT=https://www.gov.uk
GOVUK_WEBSITE_ROOT=https://www.gov.uk
PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api
PLEK_SERVICE_STATIC_URI=assets.publishing.service.gov.uk
DERAILED_SKIP_ACTIVE_RECORD=true TEST_COUNT=100
PATH_TO_HIT=/government/case-studies/nda-archive SLIMMER_DEV=1 bundle
exec derailed exec perf:objects
```

This makes a 100 requests to the app and outputs stats on memory usage.

Before this change (master):

```
Total allocated: 159341340 bytes (1415052 objects)
Total retained:  680097 bytes (5510 objects)
```

After this change:

```
Total allocated: 106879912 bytes (931658 objects)
Total retained:  141145 bytes (551 objects)
```

This change has run for on staging in `specialist-frontend` and `multipage-frontend` (see https://github.com/alphagov/slimmer/pull/189). It shows a nice improvement over the weekend:

<img width="1289" alt="screen shot 2017-02-27 at 12 15 06" src="https://cloud.githubusercontent.com/assets/233676/23361095/ca018560-fce6-11e6-8cda-af048015ba93.png">

The last hours show a little increase in memory usage, but it's probably still better than the current situation.

https://trello.com/c/MPcAEGbL/851-frontend-apps-memory-leak
https://trello.com/c/TYpcs2W1