### PR TITLE
Disable caching in development

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -10,7 +10,11 @@ module Slimmer
   CACHE_TTL = 900
 
   def self.cache
-    @cache ||= defined?(Rails) ? Rails.cache : NoCache.new
+    @cache ||= should_cache? ? Rails.cache : NoCache.new
+  end
+
+  def self.should_cache?
+    defined?(Rails) && ENV['RACK_ENV'] != 'development'
   end
 
   class NoCache


### PR DESCRIPTION
When running slimmer in development, the cache prevents changes from being visible immediately, which impedes the development cycle (for example, when editing govuk components in `static`).

This change checks `RACK_ENV`, and if it's set to `development`, we disable caching.