### PR TITLE
Change the default error on strict html failure to warn on dev and test

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'null_logger'
   s.add_dependency 'rest-client'
   s.add_dependency 'activesupport'
+  s.add_dependency 'colorize'
 
   s.add_development_dependency 'yard', '0.8.7.6'
   s.add_development_dependency 'minitest', '~> 5.4'


### PR DESCRIPTION
Previously you had fundamentally different behaviour on dev as your do
in production. It used to raise only on dev and test, and silently
fall through on production. The content items on live are not
always vaild in respect to multiple id's. This pull makes it warn
in the console, and have the bell sound so you can render pages,
while still keeping a reasonable warning in place.

I Think ideally we would raise a logging error on production too,
but we need to make sure the consequences of that would be ok,
this may be tackled in a further pull. Making sure that valid html is
coming through from govspeak, shuld ideally be tackled by the govspeak
gem/publisher at the source, so they can fix the errors when they create
them.

The code for doing the logging in slimmer seems to be a bit hokey
so i have overridden to use the default rails logger on dev and test
if it is there. For some reason, it passes in a nil logger,
and then also overrides that in this class, so i used a small hammer
as it would involve unwinding a lot of logging behaviour,
which i did try.