### PR TITLE
Change airbrake call to be compatible with airbrake v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 10.1.4
+
+* Adjust airbrake to work on airbrake v4 or v5
+
 # 10.1.3
 
 * Fix memory leak in components

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -85,7 +85,7 @@ module Slimmer
         rescue => e
           logger.error "Slimmer: Failed while processing #{p}: #{[ e.message, e.backtrace ].flatten.join("\n")}"
           if defined?(Airbrake)
-            Airbrake.notify(e, rack_env: rack_env)
+            Airbrake.notify_sync(e, rack_env: rack_env)
           end
           raise if strict
         end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -85,7 +85,7 @@ module Slimmer
         rescue => e
           logger.error "Slimmer: Failed while processing #{p}: #{[ e.message, e.backtrace ].flatten.join("\n")}"
           if defined?(Airbrake)
-            Airbrake.notify_or_ignore(e, rack_env: rack_env)
+            Airbrake.notify(e, rack_env: rack_env)
           end
           raise if strict
         end

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '10.1.3'
+  VERSION = '10.1.4'
 end


### PR DESCRIPTION
Airbrake has removed the notify_or_ignore, in favour of just notify
i fixed this by just making it go through notify, which exists in
airbake 4 and 5

https://github.com/airbrake/airbrake/blob/master/docs/Migration_guide_from_v4_to_v5.md#notify-or-ignore