### PR TITLE
Upgrade nokogiri dependency

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "slimmer"
 
-  s.add_dependency 'nokogiri', '>= 1.5.0', '< 1.7.0'
+  s.add_dependency 'nokogiri', '~> 1.7'
   s.add_dependency 'rack'
   s.add_dependency 'plek', '>= 1.1.0'
   s.add_dependency 'json'


### PR DESCRIPTION
This commit upgrades the `nokogiri` dependency to `~> 1.7` due to a number of security vulnerabilities with `~> 1.6`, to allow apps using `nokogiri` to upgrade their versions.