### PR TITLE
Raise error so pages are not cached

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -87,7 +87,7 @@ module Slimmer
           if defined?(Airbrake)
             Airbrake.notify(e, rack_env: rack_env)
           end
-          raise if strict
+          raise
         end
         processor_end_time = Time.now
         process_time = processor_end_time - processor_start_time


### PR DESCRIPTION
When the body inserter fails, the page errors but the resulting error
gets cached. This means the cached error pages gets seen by users.

Raise error to avoid caching an incorrect page.

(We're pointing government-frontend at this branch here: https://github.com/alphagov/government-frontend/pull/445)