### PR TITLE
Do not catch errors from Slimmer processors

### DIFF
--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -87,7 +87,7 @@ module Slimmer
           if defined?(Airbrake)
             Airbrake.notify(e, rack_env: rack_env)
           end
-          raise if strict
+          raise
         end
         processor_end_time = Time.now
         process_time = processor_end_time - processor_start_time

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -80,15 +80,7 @@ module Slimmer
       processors.each do |p|
         processor_start_time = Time.now
         logger.debug "Slimmer: Processor #{p} started at #{processor_start_time}"
-        begin
-          p.filter(src,dest)
-        rescue => e
-          logger.error "Slimmer: Failed while processing #{p}: #{[ e.message, e.backtrace ].flatten.join("\n")}"
-          if defined?(Airbrake)
-            Airbrake.notify(e, rack_env: rack_env)
-          end
-          raise
-        end
+        p.filter(src, dest)
         processor_end_time = Time.now
         process_time = processor_end_time - processor_start_time
         logger.debug "Slimmer: Processor #{p} ended at #{processor_end_time} (#{process_time}s)"


### PR DESCRIPTION
When the body inserter fails, the page errors but the resulting error gets cached. This means the cached error pages get seen by users.  Raise errors to avoid caching an incorrect page.

Now we are no longer catching errors we do not need to specifically call Airbrake. We are also moving away from Airbrake.

Follow on from #202 and https://github.com/alphagov/government-frontend/pull/446

cc @tijmenb 