### PR TITLE
Version 11.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 11.0.1
+
+* Stop catching errors from Slimmer processors (#203)
+* Removes all references to Airbrake
+
 # 11.0.0
 
 * Drops support for nokogiri versions < 1.7.0

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '11.0.0'
+  VERSION = '11.0.1'
 end


### PR DESCRIPTION
* Stop catching errors from Slimmer processors (#203)
* Removes all references to Airbrake