### PR TITLE
Check if css tags exist in NavigationMover class

### DIFF
--- a/lib/slimmer/processors/navigation_mover.rb
+++ b/lib/slimmer/processors/navigation_mover.rb
@@ -13,9 +13,12 @@ class Slimmer::Processors::NavigationMover
       global_header['class'] = [global_header['class'], 'with-proposition'].compact.join(' ')
 
       header_block = Nokogiri::HTML.fragment(proposition_header_block)
-      header_block.at_css('.content') << proposition_header
 
-      global_header.at_css('.header-wrapper') << header_block
+      header_block_content_node = header_block.at_css('.content')
+      header_block_content_node << proposition_header if header_block_content_node
+
+      global_header_wrapper_node = global_header.at_css('.header-wrapper')
+      global_header_wrapper_node << header_block if global_header_wrapper_node
     end
   end
 


### PR DESCRIPTION
This was causing tests to fail in Whitehall. Before v11.0.1 Slimmer was swallowing these errors so this didn't have any effect. With v11.0.1, this will fail because it can't find '.content' or '.header-wrapper' tags in the test templates, returning errors in the style of `undefined method << for nil:NilClass`

See Whitehall failures here: https://github.com/alphagov/whitehall/pull/3427

Note: An alternative solution might be to update the test templates by adding `.content` and `.header-wrapper` tags... but I couldn't figure out if those elements are standard elements (and where those are defined).