### PR TITLE
Add missing class tags to test templates

### DIFF
--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -3,7 +3,9 @@
     <title>Test Template</title>
   </head>
   <body>
-    <header id="global-header"></header>
+    <header id="global-header">
+      <div class="header-wrapper"></div>
+    </header>
     <div id="global-breadcrumb" class="header-context">
       <nav role="navigation">
         <ol class="group">

--- a/lib/slimmer/test_templates/proposition_menu.html
+++ b/lib/slimmer/test_templates/proposition_menu.html
@@ -1,0 +1,7 @@
+<div class="header-proposition">
+  <div class="content">
+    <nav id="proposition-menu">
+      <a href="#">Navigation item</a>
+    </nav>
+  </div>
+</div>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -3,7 +3,9 @@
     <title>Test Template</title>
   </head>
   <body>
-    <header id="global-header"></header>
+    <header id="global-header">
+      <div class="header-wrapper"></div>
+    </header>
     <div id="global-breadcrumb" class="header-context">
       <nav role="navigation">
         <ol class="group">


### PR DESCRIPTION
When using slimmer in test mode, instead of getting templates from Static it returns these test templates. They were missing some class tags as required by the NavigationMover class, which in turn made Whitehall tests fail (in a not very obvious way).

Alternative for https://github.com/alphagov/slimmer/pull/205

See Whitehall failures here: https://github.com/alphagov/whitehall/pull/3427