### PR TITLE
Replace after filter with after action

### DIFF
--- a/lib/slimmer/template.rb
+++ b/lib/slimmer/template.rb
@@ -11,7 +11,7 @@ module Slimmer
 
     module ClassMethods
       def slimmer_template template_name
-        after_filter do
+        after_action do
           response.headers[Slimmer::Headers::TEMPLATE_HEADER] ||= template_name.to_s
         end
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/6BqK4u39/740-5-move-smart-answers-from-errbit-to-sentry)

## Description 
Following the upgrade of govuk apps to rails 5, certain gems like this may not have been altered to match rails 5 apps. Also at the moment smart answer requires an update beyond 5.0.2 and this isn't possible becuase newer version of rails only support after_action.

This PR makes this switch under the assumption that all gov.uk apps are
now rails 5 compliant.