### PR TITLE
Make 'inside header inserter' more resilient

### DIFF
--- a/lib/slimmer/processors/inside_header_inserter.rb
+++ b/lib/slimmer/processors/inside_header_inserter.rb
@@ -4,7 +4,8 @@ module Slimmer::Processors
       insertion = src.at_css('.slimmer-inside-header')
 
       if insertion
-        dest.at_css('.header-logo').add_next_sibling(insertion.inner_html)
+        logo = dest.at_css('.header-logo')
+        logo.add_next_sibling(insertion.inner_html) unless logo.nil?
       end
     end
   end

--- a/test/processors/inside_header_inserter_test.rb
+++ b/test/processors/inside_header_inserter_test.rb
@@ -32,4 +32,24 @@ class InsideHeaderInserterTest < MiniTest::Test
       "Inserted Page Title",
       'Expecting the H2 to be inserted after .header-logo'
   end
+
+  def test_should_fail_gracefully_if_logo_not_present
+    source = as_nokogiri %{
+      <html>
+        <body>
+          <div class="slimmer-inside-header">
+            <h2>Inserted Page Title</h2>
+          </div>
+        </body>
+      </html>
+    }
+    template = as_nokogiri %{
+      <html>
+        <body></body>
+      </html>
+    }
+
+    # No exception should be thrown
+    Slimmer::Processors::InsideHeaderInserter.new.filter(source, template)
+  end
 end


### PR DESCRIPTION
Some applications (like Service Manual Frontend) opt into using Slimmer for their javascript tests (so that they get e.g. jQuery) but in a test context the header logo is stubbed out, so this breaks.

This was previously masked by Slimmer swallowing exceptions raised within the processors, but this was removed in #203.