### PR TITLE
Fix set slimmer headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 12.0.0
+
+* Change `set_slimmer_headers` to be Rails 4 and 5 compatible.
+
 # 11.1.1
 
 * Make the 'Inside Header Inserter' more resillient so that it doesn't throw

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -78,7 +78,12 @@ module Slimmer
       raise InvalidHeader if (hash.keys - SLIMMER_HEADER_MAPPING.keys).any?
       SLIMMER_HEADER_MAPPING.each do |hash_key, header_suffix|
         value = hash[hash_key]
-        headers["#{HEADER_PREFIX}-#{header_suffix}"] = value.to_s if value
+        if value
+          header = "#{HEADER_PREFIX}-#{header_suffix}"
+          # set_header is not available in rails 4.
+          # This conditional can be removed once all app are running >= rails 5.
+          respond_to?(:set_header) ? set_header(header, value.to_s) : (headers[header] = value.to_s)
+        end
       end
     end
   end

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '11.1.1'
+  VERSION = '12.0.0'
 end

--- a/test/headers_rails_4_test.rb
+++ b/test/headers_rails_4_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 require "slimmer/headers"
 
-class HeadersTest < MiniTest::Test
+class HeadersRails4Test < MiniTest::Test
   include Slimmer::Headers
   attr_accessor :headers
 
@@ -9,48 +9,44 @@ class HeadersTest < MiniTest::Test
     self.headers = {}
   end
 
-  def set_header(key, value)
-    headers[key] = value
-  end
-
   def test_should_set_section_header
-    self.expects(:set_header).with("X-Slimmer-Section", "rhubarb")
     set_slimmer_headers section: "rhubarb"
+    assert_equal "rhubarb", headers["X-Slimmer-Section"]
   end
 
   def test_should_set_format_header
-    self.expects(:set_header).with("X-Slimmer-Format", "rhubarb")
     set_slimmer_headers format: "rhubarb"
+    assert_equal "rhubarb", headers["X-Slimmer-Format"]
   end
 
   def test_should_set_application_name_header
-    self.expects(:set_header).with("X-Slimmer-Application-Name", "whitehall")
     set_slimmer_headers application_name: "whitehall"
+    assert_equal "whitehall", headers["X-Slimmer-Application-Name"]
   end
 
   def test_should_set_page_owner_header
-    self.expects(:set_header).with("X-Slimmer-Page-Owner", "bobby")
     set_slimmer_headers page_owner: "bobby"
+    assert_equal "bobby", headers["X-Slimmer-Page-Owner"]
   end
 
   def test_should_set_organisations_header
-    self.expects(:set_header).with("X-Slimmer-Organisations", "<D123><P1>")
     set_slimmer_headers organisations: "<D123><P1>"
+    assert_equal "<D123><P1>", headers["X-Slimmer-Organisations"]
   end
 
   def test_should_set_result_count_header
-    self.expects(:set_header).with("X-Slimmer-Result-Count", "3")
     set_slimmer_headers result_count: 3
+    assert_equal "3", headers["X-Slimmer-Result-Count"]
   end
 
   def test_should_set_template_header
-    self.expects(:set_header).with("X-Slimmer-Template", "rhubarb")
     set_slimmer_headers template: "rhubarb"
+    assert_equal "rhubarb", headers["X-Slimmer-Template"]
   end
 
   def test_should_set_skip_header
-    self.expects(:set_header).with("X-Slimmer-Skip", "rhubarb")
     set_slimmer_headers skip: "rhubarb"
+    assert_equal "rhubarb", headers["X-Slimmer-Skip"]
   end
 
   def test_should_raise_an_exception_if_a_header_has_a_typo


### PR DESCRIPTION
Rails 5 uses `set_header` instead of the `headers` hash.