### PR TITLE
Make sure we insert meta tags above template metatags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Make sure that the metatags defined in the application are inserted at the
+  top of the page. This means that third parties will see the custom metatags
+  like `og:image` first, and template tags like the default sharing image second (#218) 
+
 # 12.0.0
 
 * Remove the "report a problem" feature. This is now being covered by the

--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -3,8 +3,8 @@ module Slimmer::Processors
     def filter(src,dest)
       move_tags(src, dest, 'script', :dest_node => 'body', :keys => ['src', 'inner_html'])
       move_tags(src, dest, 'link',   :must_have => ['href'])
-      move_tags(src, dest, 'meta',   :must_have => ['name', 'content'], :keys => ['name', 'content', 'http-equiv'])
-      move_tags(src, dest, 'meta',   :must_have => ['property', 'content'], :keys => ['property', 'content'])
+      move_tags(src, dest, 'meta',   :must_have => ['name', 'content'], :keys => ['name', 'content', 'http-equiv'], insertion_location: :top)
+      move_tags(src, dest, 'meta',   :must_have => ['property', 'content'], :keys => ['property', 'content'], insertion_location: :top)
     end
 
     def include_tag?(node, min_attrs)
@@ -40,7 +40,12 @@ module Slimmer::Processors
         if include_tag?(node, min_attrs) && !already_there.include?(tag_fingerprint(node, comparison_attrs))
           node = wrap_node(src, node)
           node.remove
-          dest.at_xpath("/html/#{dest_node}") << node
+
+          if opts[:insertion_location] == :top
+            dest.at_xpath("/html/#{dest_node}").prepend_child(node)
+          else
+            dest.at_xpath("/html/#{dest_node}") << node
+          end
         end
       end
     end

--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -1,10 +1,10 @@
 module Slimmer::Processors
   class TagMover
-    def filter(src,dest)
-      move_tags(src, dest, 'script', :dest_node => 'body', :keys => ['src', 'inner_html'])
-      move_tags(src, dest, 'link',   :must_have => ['href'])
-      move_tags(src, dest, 'meta',   :must_have => ['name', 'content'], :keys => ['name', 'content', 'http-equiv'], insertion_location: :top)
-      move_tags(src, dest, 'meta',   :must_have => ['property', 'content'], :keys => ['property', 'content'], insertion_location: :top)
+    def filter(src, dest)
+      move_tags(src, dest, 'script', dest_node: 'body', keys: %w(src inner_html))
+      move_tags(src, dest, 'link',   must_have: ['href'])
+      move_tags(src, dest, 'meta',   must_have: %w(name content), keys: ['name', 'content', 'http-equiv'], insertion_location: :top)
+      move_tags(src, dest, 'meta',   must_have: %w(property content), keys: %w(property content), insertion_location: :top)
     end
 
     def include_tag?(node, min_attrs)
@@ -22,7 +22,7 @@ module Slimmer::Processors
     end
 
     def wrap_node(src, node)
-      if node.previous_sibling.to_s =~ /<!--\[if[^\]]+\]><!-->/ and node.next_sibling.to_s == '<!--<![endif]-->'
+      if node.previous_sibling.to_s =~ /<!--\[if[^\]]+\]><!-->/ && node.next_sibling.to_s == '<!--<![endif]-->'
         node = Nokogiri::XML::NodeSet.new(src, [node.previous_sibling, node, node.next_sibling])
       end
       node

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -16,6 +16,7 @@ class TagMoverTest < MiniTest::Test
           <meta property="p:baz" content="bat" />
           <meta property="p:empty" />
           <meta property="p:duplicate" content="name and content" />
+          <meta property="og:image" content="custom-og-image" />
         </head>
         <body class="mainstream">
           <div id="wrapper"></div>
@@ -30,6 +31,7 @@ class TagMoverTest < MiniTest::Test
           <link rel="stylesheet" href="http://www.example.com/duplicate.css" />
           <meta name="duplicate" content="name and content" />
           <meta property="p:duplicate" content="name and content" />
+          <meta property="og:image" content="default-og-image" />
         </head>
         <body class="mainstream">
           <div id="wrapper"></div>
@@ -70,6 +72,10 @@ class TagMoverTest < MiniTest::Test
 
   def test_should_move_meta_tags_into_the_head
     assert_in @template, "meta[name='foo'][content='bar']", nil, "Should have moved the foo=bar meta tag"
+  end
+
+  def test_should_place_metatags_on_top
+    assert @template.to_s.index("custom-og-image") < @template.to_s.index("default-og-image"), "Expected meta tags to be inserted to the top of the header"
   end
 
   def test_should_ignore_meta_tags_with_no_name_or_content


### PR DESCRIPTION
When combining the template and application HTML, the `TagMover` will take the meta and script tags from the application HTML and move them to the bottom of the `<head>` tag.

`TagMover` moves them to the bottom, so that the CSS of the application can override the CSS of the template (there's even a test in this gem to make sure it does it like this).

However, the desired behaviour for meta tags is the reverse. In particular, we want the `og:image` from the application to be higher than the `og:image` from the template. This is because services like Slack will choose the first `og:image` tag and not the more appropriate custom one.

I tried to do this in https://github.com/alphagov/govuk_template/pull/349, but I forgot that life isn't easy and Slimmer exists.

Will enable https://github.com/alphagov/government-frontend/pull/878 to work properly.