### PR TITLE
Drop cache TTL to 60 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Drop cache TTL to 60 seconds.
+
 # 12.1.0
 
 * Make sure that the metatags defined in the application are inserted at the

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -7,7 +7,7 @@ require 'slimmer/version'
 require 'slimmer/railtie' if defined? Rails
 
 module Slimmer
-  CACHE_TTL = 900
+  CACHE_TTL = 60
 
   def self.cache
     @cache ||= defined?(Rails) ? Rails.cache : NoCache.new


### PR DESCRIPTION
We experienced an [incident yesterday][1] that might have been caught on staging if it wasn't for the delay between deploying to staging and the caches expiring. By moving to a minute long cache we increase the likelihood of noticing issues quickly after deploy.

The requests made are very fast anyway, so this is not likely to impact load speed very much.

[1]: https://docs.google.com/document/d/1Hyg48BZVi0gVFkYO2FMDv7F797X3pOi-wbc7pxzGTgE/edit#