### PR TITLE
Update govuk-lint

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'webmock', '1.18.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'govuk-lint', '~> 0.5.1'
+  s.add_development_dependency 'govuk-lint', '~> 3.9.0'
   s.files = Dir[
     'README.md',
     'CHANGELOG.md',


### PR DESCRIPTION
CI is failing because the linter is being passed `--parallel` as of August, but slimmer is using an ancient version.