### PR TITLE
Add `js-enabled` to test template body tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `js-enabled` to body tag of test templates.
+
 # 13.0.0
 
 * Drop cache TTL to 60 seconds.

--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -3,6 +3,8 @@
     <title>Test Template</title>
   </head>
   <body>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
     <header id="global-header">
       <div class="header-wrapper"></div>
     </header>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -3,6 +3,8 @@
     <title>Test Template</title>
   </head>
   <body>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
     <header id="global-header">
       <div class="header-wrapper"></div>
     </header>

--- a/test/test_template_dependency_on_static_test.rb
+++ b/test/test_template_dependency_on_static_test.rb
@@ -6,7 +6,7 @@ class TestTemplateDependencyOnStaticTest < MiniTest::Test
     Dir.foreach(template_path) do | template_file_name |
       next if ['.','..'].include? template_file_name
       doc = Nokogiri::HTML.fragment(File.read(File.join(template_path, template_file_name)))
-      scripts = doc.search("script").map { |node| node.attributes["src"].value }
+      scripts = doc.search("script[src]").map { |node| node.attributes["src"].value }
       failing_scripts = allowing_real_web_connections do
         scripts.select do |script_src|
           uri = URI.parse(script_src)


### PR DESCRIPTION
Dynamically adds `js-enabled` to the `body` tag of the test templates if the template is rendered by an engine that supports JavaScript. This allows us to test JavaScript behavior that is enabled by feature detection.

This mirrors the main GOV.UK template behavior in https://github.com/alphagov/govuk_template/blob/f2c10fae7ec7e371fd11c409cd71a399e3342e7f/source/views/layouts/govuk_template.html.erb#L40

Part of https://trello.com/c/VENEFcz5