### PR TITLE
Bump govuk-lint

### DIFF
--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'webmock', '3.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'govuk-lint', '~> 3.9.0'
+  s.add_development_dependency 'govuk-lint', '~> 3.11.5'
   s.files = Dir[
     'README.md',
     'CHANGELOG.md',


### PR DESCRIPTION
This should fix trouble with Rails cops on CI (https://ci.integration.publishing.service.gov.uk/job/slimmer/job/olleolleolle-patch-1/2/console).