### PR TITLE
Bump version to 13.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 13.2.0
 
 * Upgrade Ruby version to 2.6.5. (#234)
 * Fix linting issues. (#234)

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '13.1.0'.freeze
+  VERSION = '13.2.0'.freeze
 end


### PR DESCRIPTION
Bump the version and reflect the new version in the CHANGELOG so we can prompt the release of the gem.