### PR TITLE
Fix deprecation warnings and migrate to rubocop-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+# .rubocop.yml
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   `module_parent_name`. `parent_name` is deprecated and will be removed in
   Rails 6.1. (#237)
 * Migrate from govuk-lint to rubocop-govuk (#237)
+* Remove lint rake task (#237)
 * Fix linting issues (#237)
 * Fix deprecation warning: Mocha deprecation warning at
   /my/local/path/to/test/test_helper.rb:6:in 'require': Require

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   `module_parent_name`. `parent_name` is deprecated and will be removed in
   Rails 6.1. (#237)
 * Migrate from govuk-lint to rubocop-govuk (#237)
+* Fix linting issues (#237)
 
 # 13.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix deprecation warning: `Module#parent_name` has been renamed to
   `module_parent_name`. `parent_name` is deprecated and will be removed in
   Rails 6.1. (#237)
+* Migrate from govuk-lint to rubocop-govuk (#237)
 
 # 13.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Fix deprecation warning: `Module#parent_name` has been renamed to
+  `module_parent_name`. `parent_name` is deprecated and will be removed in
+  Rails 6.1. (#237)
+
 # 13.2.0
 
 * Upgrade Ruby version to 2.6.5. (#234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
   Rails 6.1. (#237)
 * Migrate from govuk-lint to rubocop-govuk (#237)
 * Fix linting issues (#237)
+* Fix deprecation warning: Mocha deprecation warning at
+  /my/local/path/to/test/test_helper.rb:6:in 'require': Require
+  'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
+  (#237)
 
 # 13.2.0
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ node {
     }
 
     stage('Linter') {
-      govuk.rubyLinter()
+      govuk.lintRuby()
     }
 
     stage('Tests') {

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@
 
 require "bundler/gem_tasks"
 require "rdoc/task"
-require 'rake/testtask'
+require "rake/testtask"
 
-Dir.glob('lib/tasks/*.rake').each { |r| import r }
+Dir.glob("lib/tasks/*.rake").each { |r| import r }
 
 RDoc::Task.new do |rd|
   rd.rdoc_files.include("lib/**/*.rb")
@@ -18,4 +18,4 @@ Rake::TestTask.new("test") do |t|
   t.verbose = true
 end
 
-task :default => [:test, :lint]
+task default: %i[test]

--- a/bin/render_slimmer_error
+++ b/bin/render_slimmer_error
@@ -1,26 +1,25 @@
 #! /usr/bin/env ruby
 
-require 'optparse'
-require 'slimmer'
-require 'logger'
+require "optparse"
+require "slimmer"
+require "logger"
 
 options = {}
-OptionParser.new do |opts|
-  opts.on '-t', '--template=TEMPLATE',
-    'Template to render' do |v|
+option_parser = OptionParser.new do |opts|
+  opts.on "-t", "--template=TEMPLATE", "Template to render" do |v|
     options[:template] = v
   end
 
-  opts.on '-h', '--asset-host=HOST',
-    'Host that serves assets used in the template' do |v|
+  opts.on "-h", "--asset-host=HOST", "Host that serves assets used in the template" do |v|
     options[:asset_host] = v
   end
 
-  opts.on '-o', '--output-file=FILE',
-    'File to write static error page to' do |v|
+  opts.on "-o", "--output-file=FILE", "File to write static error page to" do |v|
     options[:file] = v
   end
-end.parse!
+end
+
+option_parser.parse!
 
 raise "Please specify a template" unless options[:template]
 raise "Please specify an asset host" unless options[:asset_host]
@@ -28,13 +27,13 @@ raise "Please specify an output file" unless options[:file]
 
 logger = Logger.new STDOUT
 logger.level = Logger::DEBUG
-skin = Slimmer::Skin.new options[:asset_host], false, :logger => logger
+skin = Slimmer::Skin.new options[:asset_host], false, logger: logger
 static_error = skin.error nil, options[:template], Nokogiri::HTML("").to_html
 
-if options[:file] == '-'
+if options[:file] == "-"
   STDOUT.print static_error
 else
-  File.open options[:file], 'w' do |f|
+  File.open options[:file], "w" do |f|
     f.print static_error
   end
 end

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -21,4 +21,4 @@ test 4.2.x 2.3
 test 4.2.x 2.2
 
 bundle install --path "${HOME}/bundles/${JOB_NAME}"
-bundle exec rake lint
+bundle exec rubocop --format clang

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -1,10 +1,10 @@
-require 'nokogiri'
-require 'erb'
-require 'plek'
-require 'null_logger'
+require "nokogiri"
+require "erb"
+require "plek"
+require "null_logger"
 
-require 'slimmer/version'
-require 'slimmer/railtie' if defined? Rails
+require "slimmer/version"
+require "slimmer/railtie" if defined? Rails
 
 module Slimmer
   CACHE_TTL = 60
@@ -19,29 +19,29 @@ module Slimmer
     end
   end
 
-  autoload :Railtie, 'slimmer/railtie'
-  autoload :Skin, 'slimmer/skin'
+  autoload :Railtie, "slimmer/railtie"
+  autoload :Skin, "slimmer/skin"
 
-  autoload :Template, 'slimmer/template'
-  autoload :App, 'slimmer/app'
-  autoload :Headers, 'slimmer/headers'
-  autoload :HTTPClient, 'slimmer/http_client'
+  autoload :Template, "slimmer/template"
+  autoload :App, "slimmer/app"
+  autoload :Headers, "slimmer/headers"
+  autoload :HTTPClient, "slimmer/http_client"
 
   module Processors
-    autoload :BodyClassCopier, 'slimmer/processors/body_class_copier'
-    autoload :BodyInserter, 'slimmer/processors/body_inserter'
-    autoload :ConditionalCommentMover, 'slimmer/processors/conditional_comment_mover'
-    autoload :FooterRemover, 'slimmer/processors/footer_remover'
-    autoload :MetadataInserter, 'slimmer/processors/metadata_inserter'
-    autoload :HeaderContextInserter, 'slimmer/processors/header_context_inserter'
-    autoload :InsideHeaderInserter, 'slimmer/processors/inside_header_inserter'
-    autoload :NavigationMover, 'slimmer/processors/navigation_mover'
-    autoload :SearchIndexSetter, 'slimmer/processors/search_index_setter'
-    autoload :SearchPathSetter, 'slimmer/processors/search_path_setter'
-    autoload :SearchParameterInserter, 'slimmer/processors/search_parameter_inserter'
-    autoload :SearchRemover, 'slimmer/processors/search_remover'
-    autoload :TagMover, 'slimmer/processors/tag_mover'
-    autoload :TitleInserter, 'slimmer/processors/title_inserter'
+    autoload :BodyClassCopier, "slimmer/processors/body_class_copier"
+    autoload :BodyInserter, "slimmer/processors/body_inserter"
+    autoload :ConditionalCommentMover, "slimmer/processors/conditional_comment_mover"
+    autoload :FooterRemover, "slimmer/processors/footer_remover"
+    autoload :MetadataInserter, "slimmer/processors/metadata_inserter"
+    autoload :HeaderContextInserter, "slimmer/processors/header_context_inserter"
+    autoload :InsideHeaderInserter, "slimmer/processors/inside_header_inserter"
+    autoload :NavigationMover, "slimmer/processors/navigation_mover"
+    autoload :SearchIndexSetter, "slimmer/processors/search_index_setter"
+    autoload :SearchPathSetter, "slimmer/processors/search_path_setter"
+    autoload :SearchParameterInserter, "slimmer/processors/search_parameter_inserter"
+    autoload :SearchRemover, "slimmer/processors/search_remover"
+    autoload :TagMover, "slimmer/processors/tag_mover"
+    autoload :TitleInserter, "slimmer/processors/title_inserter"
   end
 
   class TemplateNotFoundException < StandardError; end

--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -1,4 +1,4 @@
-require 'slimmer/govuk_request_id'
+require "slimmer/govuk_request_id"
 
 module Slimmer
   class App
@@ -10,15 +10,11 @@ module Slimmer
 
       logger = options[:logger] || NullLogger.instance
       self.logger = logger
-      begin
-        if logger.level.zero? # Log set to debug level
-          unless options[:enable_debugging]
-            self.logger = logger.dup
-            self.logger.level = 1 # info
-          end
+      if logger&.level&.zero? # Log set to debug level
+        unless options[:enable_debugging]
+          self.logger = logger.dup
+          self.logger.level = 1 # info
         end
-      rescue NoMethodError # rubocop:disable Lint/HandleExceptions
-        # In case logger doesn't respond_to? :level
       end
 
       if options.key? :template_path
@@ -56,11 +52,11 @@ module Slimmer
     end
 
     def in_development?
-      ENV['RAILS_ENV'] == 'development'
+      ENV["RAILS_ENV"] == "development"
     end
 
     def skip_slimmer_param?(env)
-      skip = Rack::Request.new(env).params['skip_slimmer']
+      skip = Rack::Request.new(env).params["skip_slimmer"]
       skip && skip.to_i.positive?
     end
 
@@ -86,24 +82,24 @@ module Slimmer
       request = Rack::Request.new(env)
 
       # Store the request id so it can be passed on with any template requests
-      GovukRequestId.value = env['HTTP_GOVUK_REQUEST_ID']
+      GovukRequestId.value = env["HTTP_GOVUK_REQUEST_ID"]
 
       rewritten_body = case response.status
                        when 200
                          @skin.success request, response, s(response.body)
                        when 403
-                         @skin.error '403', s(response.body), request.env
+                         @skin.error "403", s(response.body), request.env
                        when 404
-                         @skin.error '404', s(response.body), request.env
+                         @skin.error "404", s(response.body), request.env
                        when 410
-                         @skin.error '410', s(response.body), request.env
+                         @skin.error "410", s(response.body), request.env
                        else
-                         @skin.error '500', s(response.body), request.env
+                         @skin.error "500", s(response.body), request.env
                        end
 
       rewritten_body = [rewritten_body] unless rewritten_body.respond_to?(:each)
       response.body = rewritten_body
-      response.headers['Content-Length'] = content_length(response.body)
+      response.headers["Content-Length"] = content_length(response.body)
 
       response.finish
     end

--- a/lib/slimmer/cucumber.rb
+++ b/lib/slimmer/cucumber.rb
@@ -1,3 +1,3 @@
-require 'cucumber'
+require "cucumber"
 
-require 'slimmer/test'
+require "slimmer/test"

--- a/lib/slimmer/processors/body_class_copier.rb
+++ b/lib/slimmer/processors/body_class_copier.rb
@@ -2,11 +2,11 @@ module Slimmer::Processors
   class BodyClassCopier
     def filter(src, dest)
       src_body_tag = src.at_css("body")
-      dest_body_tag = dest.at_css('body')
+      dest_body_tag = dest.at_css("body")
       if src_body_tag.has_attribute?("class")
-        combinded_classes = dest_body_tag.attr('class').to_s.split(/ +/)
-        combinded_classes << src_body_tag.attr('class').to_s.split(/ +/)
-        dest_body_tag.set_attribute("class", combinded_classes.join(' '))
+        combinded_classes = dest_body_tag.attr("class").to_s.split(/ +/)
+        combinded_classes << src_body_tag.attr("class").to_s.split(/ +/)
+        dest_body_tag.set_attribute("class", combinded_classes.join(" "))
       end
     end
   end

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -1,8 +1,8 @@
 module Slimmer::Processors
   class BodyInserter
-    def initialize(source_id = 'wrapper', destination_id = 'wrapper')
-      @source_selector = '#' + source_id
-      @destination_selector = '#' + destination_id
+    def initialize(source_id = "wrapper", destination_id = "wrapper")
+      @source_selector = "#" + source_id
+      @destination_selector = "#" + destination_id
     end
 
     def filter(src, dest)

--- a/lib/slimmer/processors/conditional_comment_mover.rb
+++ b/lib/slimmer/processors/conditional_comment_mover.rb
@@ -1,9 +1,9 @@
 module Slimmer::Processors
   class ConditionalCommentMover
     def filter(src, dest)
-      src.xpath('//comment()').each do |comment|
+      src.xpath("//comment()").each do |comment|
         if match_conditional_comments(comment)
-          dest.at_xpath('/html/head') << comment
+          dest.at_xpath("/html/head") << comment
         end
       end
     end

--- a/lib/slimmer/processors/header_context_inserter.rb
+++ b/lib/slimmer/processors/header_context_inserter.rb
@@ -1,6 +1,6 @@
 module Slimmer::Processors
   class HeaderContextInserter
-    def initialize(path = '.header-context')
+    def initialize(path = ".header-context")
       @path = path
     end
 

--- a/lib/slimmer/processors/inside_header_inserter.rb
+++ b/lib/slimmer/processors/inside_header_inserter.rb
@@ -1,10 +1,10 @@
 module Slimmer::Processors
   class InsideHeaderInserter
     def filter(src, dest)
-      insertion = src.at_css('.slimmer-inside-header')
+      insertion = src.at_css(".slimmer-inside-header")
 
       if insertion
-        logo = dest.at_css('.header-logo')
+        logo = dest.at_css(".header-logo")
         logo.add_next_sibling(insertion.inner_html) unless logo.nil?
       end
     end

--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -6,22 +6,22 @@ module Slimmer::Processors
     end
 
     def filter(_src, dest)
-      head = dest.at_css('head')
+      head = dest.at_css("head")
 
-      add_meta_tag('analytics:organisations', @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head)
-      add_meta_tag('analytics:world-locations', @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head)
-      add_meta_tag('format', @headers[Slimmer::Headers::FORMAT_HEADER], head)
-      add_meta_tag('search-result-count', @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head)
-      add_meta_tag('rendering-application', @app_name, head)
+      add_meta_tag("analytics:organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head)
+      add_meta_tag("analytics:world-locations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head)
+      add_meta_tag("format", @headers[Slimmer::Headers::FORMAT_HEADER], head)
+      add_meta_tag("search-result-count", @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head)
+      add_meta_tag("rendering-application", @app_name, head)
     end
 
   private
 
     def add_meta_tag(name, content, head)
       if content
-        meta_node = Nokogiri::XML::Node.new('meta', head)
-        meta_node['name'] = "govuk:#{name}"
-        meta_node['content'] = content
+        meta_node = Nokogiri::XML::Node.new("meta", head)
+        meta_node["name"] = "govuk:#{name}"
+        meta_node["content"] = content
 
         head.add_child(meta_node)
       end

--- a/lib/slimmer/processors/navigation_mover.rb
+++ b/lib/slimmer/processors/navigation_mover.rb
@@ -9,16 +9,16 @@ class Slimmer::Processors::NavigationMover
     if proposition_header && global_header
       proposition_header.remove
 
-      global_header['class'] = [global_header['class'], 'with-proposition'].compact.join(' ')
+      global_header["class"] = [global_header["class"], "with-proposition"].compact.join(" ")
 
       header_block = Nokogiri::HTML.fragment(proposition_header_block)
-      header_block.at_css('.content') << proposition_header
+      header_block.at_css(".content") << proposition_header
 
-      global_header.at_css('.header-wrapper') << header_block
+      global_header.at_css(".header-wrapper") << header_block
     end
   end
 
   def proposition_header_block
-    @proposition_header_block ||= @skin.template('proposition_menu')
+    @proposition_header_block ||= @skin.template("proposition_menu")
   end
 end

--- a/lib/slimmer/processors/search_parameter_inserter.rb
+++ b/lib/slimmer/processors/search_parameter_inserter.rb
@@ -1,4 +1,4 @@
-require 'json'
+require "json"
 
 module Slimmer::Processors
   class SearchParameterInserter
@@ -7,7 +7,7 @@ module Slimmer::Processors
     end
 
     def filter(_content_document, page_template)
-      search_form = page_template.at_css('form#search')
+      search_form = page_template.at_css("form#search")
       if search_parameters && search_form
         search_parameters.each_pair do |name, value|
           # Value can either be a string or an array of values
@@ -24,10 +24,10 @@ module Slimmer::Processors
     end
 
     def add_hidden_input(search_form, name, value)
-      element = Nokogiri::XML::Node.new('input', search_form)
-      element['type'] = 'hidden'
-      element['name'] = name
-      element['value'] = value.to_s
+      element = Nokogiri::XML::Node.new("input", search_form)
+      element["type"] = "hidden"
+      element["name"] = name
+      element["value"] = value.to_s
       search_form.add_child(element)
     end
 

--- a/lib/slimmer/processors/search_path_setter.rb
+++ b/lib/slimmer/processors/search_path_setter.rb
@@ -5,8 +5,8 @@ module Slimmer::Processors
     end
 
     def filter(_content_document, page_template)
-      if search_scope && page_template.at_css('form#search')
-        page_template.at_css('form#search').attributes["action"].value = search_scope
+      if search_scope && page_template.at_css("form#search")
+        page_template.at_css("form#search").attributes["action"].value = search_scope
       end
     end
 

--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -1,10 +1,10 @@
 module Slimmer::Processors
   class TagMover
     def filter(src, dest)
-      move_tags(src, dest, 'script', dest_node: 'body', keys: %w(src inner_html))
-      move_tags(src, dest, 'link',   must_have: %w[href])
-      move_tags(src, dest, 'meta',   must_have: %w(name content), keys: %w[name content http-equiv], insertion_location: :top)
-      move_tags(src, dest, 'meta',   must_have: %w(property content), keys: %w(property content), insertion_location: :top)
+      move_tags(src, dest, "script", dest_node: "body", keys: %w(src inner_html))
+      move_tags(src, dest, "link",   must_have: %w[href])
+      move_tags(src, dest, "meta",   must_have: %w(name content), keys: %w[name content http-equiv], insertion_location: :top)
+      move_tags(src, dest, "meta",   must_have: %w(property content), keys: %w(property content), insertion_location: :top)
     end
 
     def include_tag?(node, min_attrs)
@@ -13,7 +13,7 @@ module Slimmer::Processors
 
     def tag_fingerprint(node, attrs)
       collected_attrs = attrs.collect do |attr_name|
-        if attr_name == 'inner_html'
+        if attr_name == "inner_html"
           node.content
         else
           node.has_attribute?(attr_name) ? node.attr(attr_name) : nil
@@ -24,7 +24,7 @@ module Slimmer::Processors
     end
 
     def wrap_node(src, node)
-      if node.previous_sibling.to_s =~ /<!--\[if[^\]]+\]><!-->/ && node.next_sibling.to_s == '<!--<![endif]-->'
+      if node.previous_sibling.to_s =~ /<!--\[if[^\]]+\]><!-->/ && node.next_sibling.to_s == "<!--<![endif]-->"
         node = Nokogiri::XML::NodeSet.new(src, [node.previous_sibling, node, node.next_sibling])
       end
       node
@@ -36,7 +36,7 @@ module Slimmer::Processors
       already_there = dest.css(type).map { |node|
         tag_fingerprint(node, comparison_attrs)
       }.compact
-      dest_node = opts[:dest_node] || 'head'
+      dest_node = opts[:dest_node] || "head"
 
       src.css(type).each do |node|
         if include_tag?(node, min_attrs) && !already_there.include?(tag_fingerprint(node, comparison_attrs))

--- a/lib/slimmer/processors/title_inserter.rb
+++ b/lib/slimmer/processors/title_inserter.rb
@@ -1,18 +1,18 @@
 module Slimmer::Processors
   class TitleInserter
     def filter(src, dest)
-      title = src.at_css('head title')
-      head  = dest.at_xpath('/html/head')
+      title = src.at_css("head title")
+      head  = dest.at_xpath("/html/head")
       if head && title
         insert_title(title, head)
       end
     end
 
     def insert_title(title, head)
-      if head.at_css('title').nil?
+      if head.at_css("title").nil?
         head.first_element_child.nil? ? head << title : head.first_element_child.before(title)
       else
-        head.at_css('title').replace(title)
+        head.at_css("title").replace(title)
       end
     end
   end

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -5,7 +5,7 @@ module Slimmer
     initializer "slimmer.configure" do |app|
       slimmer_config = app.config.slimmer.to_hash
 
-      app_name = ENV['GOVUK_APP_NAME'] || module_parent_name
+      app_name = ENV["GOVUK_APP_NAME"] || module_parent_name
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -5,10 +5,22 @@ module Slimmer
     initializer "slimmer.configure" do |app|
       slimmer_config = app.config.slimmer.to_hash
 
-      app_name = ENV['GOVUK_APP_NAME'] || app.class.parent_name
+      app_name = ENV['GOVUK_APP_NAME'] || module_parent_name
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config
+    end
+
+  private
+
+    # TODO: remove this method when all our apps are in rails 6 and substitute
+    # it with: app_name = ENV['GOVUK_APP_NAME'] || app.class.module_parent_name
+    def module_parent_name
+      if app.class.respond_to?(:module_parent_name)
+        app.class.module_parent_name
+      else
+        app.class.parent_name
+      end
     end
   end
 end

--- a/lib/slimmer/rspec.rb
+++ b/lib/slimmer/rspec.rb
@@ -1,4 +1,4 @@
-require 'rspec/core'
+require "rspec/core"
 
-require 'slimmer'
-require 'slimmer/test'
+require "slimmer"
+require "slimmer/test"

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -1,5 +1,5 @@
-require 'rest_client'
-require 'slimmer/govuk_request_id'
+require "rest_client"
+require "slimmer/govuk_request_id"
 
 module Slimmer
   class Skin
@@ -10,7 +10,7 @@ module Slimmer
       @asset_host = options[:asset_host]
 
       @logger = options[:logger] || NullLogger.instance
-      @strict = options[:strict] || %w{development test}.include?(ENV['RACK_ENV'])
+      @strict = options[:strict] || %w{development test}.include?(ENV["RACK_ENV"])
     end
 
     def template(template_name)
@@ -30,7 +30,7 @@ module Slimmer
 
     def template_url(template_name)
       host = asset_host.dup
-      host += '/' unless host =~ /\/$/
+      host += "/" unless host =~ /\/$/
       "#{host}templates/#{template_name}.html.erb"
     end
 
@@ -59,7 +59,7 @@ module Slimmer
       lines = [""] + html.split("\n")
       from = [1, error.line - context_size].max
       to = [lines.size - 1, error.line + context_size].min
-      context = (from..to).zip(lines[from..to]).map { |lineno, line| "%4d: %s" % [lineno, line] } # rubocop:disable Style/FormatStringToken
+      context = (from..to).zip(lines[from..to]).map { |lineno, line| "%4d: %s" % [lineno, line] }
       marker = " " * (error.column - 1) + "-----v"
       context.insert(context_size, marker)
       context.join("\n")
@@ -92,7 +92,7 @@ module Slimmer
     end
 
     def success(source_request, response, body)
-      wrapper_id = options[:wrapper_id] || 'wrapper'
+      wrapper_id = options[:wrapper_id] || "wrapper"
 
       processors = [
         Processors::TitleInserter.new,
@@ -109,13 +109,13 @@ module Slimmer
         Processors::SearchRemover.new(response.headers),
       ]
 
-      template_name = response.headers[Headers::TEMPLATE_HEADER] || 'core_layout'
+      template_name = response.headers[Headers::TEMPLATE_HEADER] || "core_layout"
       process(processors, body, template(template_name), source_request.env)
     end
 
     def error(template_name, body, rack_env)
       processors = [
-        Processors::TitleInserter.new
+        Processors::TitleInserter.new,
       ]
       process(processors, body, template(template_name), rack_env)
     end

--- a/lib/slimmer/test.rb
+++ b/lib/slimmer/test.rb
@@ -1,4 +1,4 @@
-require 'slimmer/skin'
+require "slimmer/skin"
 
 module Slimmer
   class Skin
@@ -6,10 +6,10 @@ module Slimmer
       logger.debug "Slimmer: TEST MODE - Loading fixture template from #{__FILE__}"
       if name =~ /\A(.*)\.raw\z/
         %{<div id="test-#{$1}"></div>}
-      elsif File.exist?(template_path = File.join(File.dirname(__FILE__), 'test_templates', "#{name}.html"))
+      elsif File.exist?(template_path = File.join(File.dirname(__FILE__), "test_templates", "#{name}.html"))
         File.read(template_path)
       else
-        File.read(File.join(File.dirname(__FILE__), 'test_templates', "wrapper.html"))
+        File.read(File.join(File.dirname(__FILE__), "test_templates", "wrapper.html"))
       end
     end
   end

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = '13.2.0'.freeze
+  VERSION = "13.2.0".freeze
 end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run rubocop with similar params to CI"
-task :lint do
-  sh "bundle exec rubocop --format clang bin lib test"
-end

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,4 @@
-desc "Run govuk-lint with similar params to CI"
+desc "Run rubocop with similar params to CI"
 task :lint do
-  sh "bundle exec govuk-lint-ruby --diff --cached --format clang bin lib test"
+  sh "bundle exec rubocop --format clang bin lib test"
 end

--- a/lib/tasks/slimmer.rake
+++ b/lib/tasks/slimmer.rake
@@ -1,4 +1,4 @@
-require 'rake'
+require "rake"
 
 namespace :slimmer do
   desc "Symlink from public directory to static directory"

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mocha', '~> 1.1'
   s.add_development_dependency 'webmock', '3.5.0'
   s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'govuk-lint', '~> 3.11.5'
+  s.add_development_dependency 'rubocop-govuk', '~> 2.0.0'
   s.files = Dir[
     'README.md',
     'CHANGELOG.md',

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -1,42 +1,43 @@
 # -*- encoding: utf-8 -*-
-lib = File.expand_path('../lib/', __FILE__)
+
+lib = File.expand_path("lib", __dir__)
 $:.unshift lib unless $:.include?(lib)
 
-require 'slimmer/version'
+require "slimmer/version"
 
-Gem::Specification.new do |s|
+Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.name        = "slimmer"
   s.version     = Slimmer::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["GOV.UK Dev"]
   s.email       = ["govuk-dev@digital.cabinet-office.gov.uk"]
   s.homepage    = "http://github.com/alphagov/slimmer"
-  s.summary     = %q{Thinner than the skinner}
-  s.description = %q{Rack middleware for skinning pages using a specific template}
-  s.license = 'MIT'
+  s.summary     = "Thinner than the skinner"
+  s.description = "Rack middleware for skinning pages using a specific template"
+  s.license = "MIT"
 
-  s.add_dependency 'nokogiri', '~> 1.7'
-  s.add_dependency 'rack'
-  s.add_dependency 'plek', '>= 1.1.0'
-  s.add_dependency 'json'
-  s.add_dependency 'null_logger'
-  s.add_dependency 'rest-client'
-  s.add_dependency 'activesupport'
+  s.add_dependency "activesupport"
+  s.add_dependency "json"
+  s.add_dependency "nokogiri", "~> 1.7"
+  s.add_dependency "null_logger"
+  s.add_dependency "plek", ">= 1.1.0"
+  s.add_dependency "rack"
+  s.add_dependency "rest-client"
 
-  s.add_development_dependency 'yard', '0.8.7.6'
-  s.add_development_dependency 'minitest', '~> 5.4'
-  s.add_development_dependency 'rake', '~> 0.9.2.2'
-  s.add_development_dependency 'rack-test', '~> 0.6.1'
-  s.add_development_dependency 'mocha', '~> 1.1'
-  s.add_development_dependency 'webmock', '3.5.0'
-  s.add_development_dependency 'timecop', '~> 0.5.1'
-  s.add_development_dependency 'rubocop-govuk', '~> 2.0.0'
+  s.add_development_dependency "minitest", "~> 5.4"
+  s.add_development_dependency "mocha", "~> 1.1"
+  s.add_development_dependency "rack-test", "~> 0.6.1"
+  s.add_development_dependency "rake", "~> 0.9.2.2"
+  s.add_development_dependency "rubocop-govuk", "~> 2.0.0"
+  s.add_development_dependency "timecop", "~> 0.5.1"
+  s.add_development_dependency "webmock", "3.5.0"
+  s.add_development_dependency "yard", "0.8.7.6"
   s.files = Dir[
-    'README.md',
-    'CHANGELOG.md',
-    'lib/**/*',
-    'Rakefile'
+    "README.md",
+    "CHANGELOG.md",
+    "lib/**/*",
+    "Rakefile"
   ]
-  s.executables   = ["render_slimmer_error"]
-  s.require_paths = ["lib"]
+  s.executables   = %w[render_slimmer_error]
+  s.require_paths = %w[lib]
 end

--- a/test/changelog_test.rb
+++ b/test/changelog_test.rb
@@ -1,10 +1,13 @@
-require_relative 'test_helper'
+require_relative "test_helper"
 
-describe 'CHANGELOG' do
-
+describe "CHANGELOG" do
   it "should have an entry for the current version" do
-    changelog_contents = File.read(File.expand_path("../../CHANGELOG.md", __FILE__))
+    changelog_contents = File.read(File.expand_path("../CHANGELOG.md", __dir__))
 
-    assert_match /^#+\s*#{Regexp.escape(Slimmer::VERSION)}/, changelog_contents, "No entry for #{Slimmer::VERSION} found in CHANGELOG.md"
+    assert_match(
+      /^#+\s*#{Regexp.escape(Slimmer::VERSION)}/,
+      changelog_contents,
+      "No entry for #{Slimmer::VERSION} found in CHANGELOG.md",
+    )
   end
 end

--- a/test/http_client_test.rb
+++ b/test/http_client_test.rb
@@ -3,10 +3,10 @@ require_relative "test_helper"
 describe Slimmer::HTTPClient do
   describe ".get" do
     it "adds the correct user agent header" do
-      ENV['GOVUK_APP_NAME'] = 'my-app'
+      ENV["GOVUK_APP_NAME"] = "my-app"
 
       request = stub_request(:get, "https://example.com/").
-        with(headers: { 'User-Agent' => "slimmer/#{Slimmer::VERSION} (my-app)" }).
+        with(headers: { "User-Agent" => "slimmer/#{Slimmer::VERSION} (my-app)" }).
         to_return(status: 200)
 
       Slimmer::HTTPClient.get("https://example.com")

--- a/test/processors/body_inserter_test.rb
+++ b/test/processors/body_inserter_test.rb
@@ -14,7 +14,7 @@ class BodyInserterTest < MiniTest::Test
   end
 
   def test_should_copy_across_unicode_characters_without_messing_with_their_encoding
-    unicode_endash = [0x2013].pack('U*')
+    unicode_endash = [0x2013].pack("U*")
     template = as_nokogiri %{
       <html><body><div><div id="wrapper"></div></div></body></html>
     }

--- a/test/processors/inside_header_inserter_test.rb
+++ b/test/processors/inside_header_inserter_test.rb
@@ -1,4 +1,4 @@
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class InsideHeaderInserterTest < MiniTest::Test
   def test_should_insert_into_header
@@ -27,10 +27,12 @@ class InsideHeaderInserterTest < MiniTest::Test
 
     Slimmer::Processors::InsideHeaderInserter.new.filter(source, template)
 
-    assert_in template,
+    assert_in(
+      template,
       "div.header-global .header-logo + h2",
       "Inserted Page Title",
-      'Expecting the H2 to be inserted after .header-logo'
+      "Expecting the H2 to be inserted after .header-logo",
+    )
   end
 
   def test_should_fail_gracefully_if_logo_not_present

--- a/test/processors/metadata_inserter_test.rb
+++ b/test/processors/metadata_inserter_test.rb
@@ -1,8 +1,7 @@
 require_relative "../test_helper"
 
 module MetadataInserterTest
-
-  GENERIC_DOCUMENT = <<-END
+  GENERIC_DOCUMENT = <<-HTML.freeze
     <html>
       <head>
         <title>The title of the page</title>
@@ -11,7 +10,7 @@ module MetadataInserterTest
         <div id="wrapper">The body of the page</div>
       </body>
     </html>
-  END
+  HTML
 
   module MetaTagAssertions
     def assert_meta_tag(name, content)
@@ -35,7 +34,7 @@ module MetadataInserterTest
         Slimmer::Headers::FORMAT_HEADER => "custard",
         Slimmer::Headers::RESULT_COUNT_HEADER => "3",
         Slimmer::Headers::ORGANISATIONS_HEADER => "<P1><D422>",
-        Slimmer::Headers::WORLD_LOCATIONS_HEADER => "<WL3>"
+        Slimmer::Headers::WORLD_LOCATIONS_HEADER => "<WL3>",
       }
 
       given_response 200, GENERIC_DOCUMENT, headers

--- a/test/processors/navigation_mover_test.rb
+++ b/test/processors/navigation_mover_test.rb
@@ -1,12 +1,12 @@
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class NavigationMoverTest < MiniTest::Test
   def setup
     super
-    @proposition_header_block = File.read( File.dirname(__FILE__) + "/../fixtures/proposition_menu.html.erb" )
-    @skin = stub("Skin", :template => @proposition_header_block)
+    @proposition_header_block = File.read(File.dirname(__FILE__) + "/../fixtures/proposition_menu.html.erb")
+    @skin = stub("Skin", template: @proposition_header_block)
   end
-  
+
   def test_should_add_proposition_menu
     source = as_nokogiri %{
       <html>

--- a/test/processors/search_parameter_inserter_test.rb
+++ b/test/processors/search_parameter_inserter_test.rb
@@ -1,8 +1,7 @@
 require "test_helper"
 
 module SearchParameterInserterTest
-
-  DOCUMENT_WITH_SEARCH = <<-END
+  DOCUMENT_WITH_SEARCH = <<-HTML.freeze
     <html>
       <head>
       </head>
@@ -13,7 +12,7 @@ module SearchParameterInserterTest
         </div>
       </body>
     </html>
-  END
+  HTML
 
   class WithHeaderTest < SlimmerIntegrationTest
     headers = {
@@ -23,7 +22,7 @@ module SearchParameterInserterTest
     given_response 200, DOCUMENT_WITH_SEARCH, headers
 
     def test_should_add_hidden_input
-      hidden_inputs = Nokogiri::HTML.parse(last_response.body).css('#search input[type=hidden]')
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).css("#search input[type=hidden]")
       assert_equal %{<input type="hidden" name="filter_organisations[]" value="land-registry"><input type="hidden" name="count" value="20">}, hidden_inputs.to_s
     end
   end
@@ -32,7 +31,7 @@ module SearchParameterInserterTest
     given_response 200, DOCUMENT_WITH_SEARCH, {}
 
     def test_should_leave_original_search_action
-      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css('#search input[type=hidden]')
+      hidden_inputs = Nokogiri::HTML.parse(last_response.body).at_css("#search input[type=hidden]")
       assert_nil hidden_inputs
     end
   end

--- a/test/processors/search_path_setter_test.rb
+++ b/test/processors/search_path_setter_test.rb
@@ -1,8 +1,7 @@
 require "test_helper"
 
 module SearchPathSetterTest
-
-  DOCUMENT_WITH_SEARCH = <<-END
+  DOCUMENT_WITH_SEARCH = <<-HTML.freeze
     <html>
       <head>
       </head>
@@ -13,7 +12,7 @@ module SearchPathSetterTest
         </div>
       </body>
     </html>
-  END
+  HTML
 
   class WithHeaderTest < SlimmerIntegrationTest
     headers = {
@@ -23,7 +22,7 @@ module SearchPathSetterTest
     given_response 200, DOCUMENT_WITH_SEARCH, headers
 
     def test_should_rewrite_search_action
-      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
+      search_action = Nokogiri::HTML.parse(last_response.body).at_css("#search")["action"]
       assert_equal "/specialist/search", search_action
     end
   end
@@ -32,7 +31,7 @@ module SearchPathSetterTest
     given_response 200, DOCUMENT_WITH_SEARCH, {}
 
     def test_should_leave_original_search_action
-      search_action = Nokogiri::HTML.parse(last_response.body).at_css('#search')["action"]
+      search_action = Nokogiri::HTML.parse(last_response.body).at_css("#search")["action"]
       assert_equal "/path/to/search", search_action
     end
   end

--- a/test/processors/search_remover_test.rb
+++ b/test/processors/search_remover_test.rb
@@ -19,7 +19,6 @@ class SearchRemoverTest < MiniTest::Test
   end
 
   def test_should_remove_search_from_template_if_header_is_set
-
     headers = { Slimmer::Headers::REMOVE_SEARCH_HEADER => true }
     Slimmer::Processors::SearchRemover.new(
       headers,
@@ -27,11 +26,9 @@ class SearchRemoverTest < MiniTest::Test
 
     assert_not_in @template, "#global-header #search"
     assert_in @template, "#search"
-
   end
 
   def test_should_not_remove_search_from_template_if_header_is_not_set
-
     headers = {}
     Slimmer::Processors::SearchRemover.new(
       headers,
@@ -41,7 +38,6 @@ class SearchRemoverTest < MiniTest::Test
   end
 
   def test_should_remove_search_link_from_template_if_header_is_set
-
     headers = { Slimmer::Headers::REMOVE_SEARCH_HEADER => true }
     Slimmer::Processors::SearchRemover.new(
       headers,
@@ -51,7 +47,6 @@ class SearchRemoverTest < MiniTest::Test
   end
 
   def test_should_not_remove_search_link_from_template_if_header_is_not_set
-
     headers = {}
     Slimmer::Processors::SearchRemover.new(
       headers,

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -56,7 +56,6 @@ class TagMoverTest < MiniTest::Test
     assert @template.to_s.index("foo.js") > @template.to_s.index("existing.js"), "Expected foo.js to be after existing.js"
   end
 
-
   def test_should_move_link_tags_into_the_head
     assert_in @template, "link[href='http://www.example.com/foo.css']", nil, "Should have moved the link tag with href 'http://www.example.com/foo.css'"
   end
@@ -68,7 +67,6 @@ class TagMoverTest < MiniTest::Test
   def test_should_ignore_link_tags_already_in_the_destination_with_the_same_href
     assert @template.css("link[href='http://www.example.com/duplicate.css']").length == 1, "Expected there to only be one link tag with href 'http://www.example.com/duplicate.css'"
   end
-
 
   def test_should_move_meta_tags_into_the_head
     assert_in @template, "meta[name='foo'][content='bar']", nil, "Should have moved the foo=bar meta tag"

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -1,15 +1,14 @@
 require_relative "test_helper"
 
 describe Slimmer::Skin do
-
   describe "loading templates" do
     it "should be able to load the template" do
       skin = Slimmer::Skin.new asset_host: "http://example.local/"
 
       expected_url = "http://example.local/templates/example.html.erb"
-      stub_request(:get, expected_url).to_return :body => "<foo />"
+      stub_request(:get, expected_url).to_return body: "<foo />"
 
-      template = skin.template 'example'
+      template = skin.template "example"
 
       assert_requested :get, expected_url
       assert_equal "<foo />", template
@@ -20,13 +19,13 @@ describe Slimmer::Skin do
         @skin = Slimmer::Skin.new asset_host: "http://example.local/"
 
         @expected_url = "http://example.local/templates/example.html.erb"
-        stub_request(:get, @expected_url).to_return :body => "<foo />"
+        stub_request(:get, @expected_url).to_return body: "<foo />"
 
-        Slimmer::GovukRequestId.value = '12345'
-        template = @skin.template('example')
+        Slimmer::GovukRequestId.value = "12345"
+        template = @skin.template("example")
 
         assert_requested :get, @expected_url do |request|
-          request.headers['Govuk-Request-Id'] == '12345'
+          request.headers["Govuk-Request-Id"] == "12345"
         end
         assert_equal "<foo />", template
       end
@@ -36,10 +35,10 @@ describe Slimmer::Skin do
       skin = Slimmer::Skin.new asset_host: "http://example.local/"
 
       expected_url = "http://example.local/templates/example.html.erb"
-      stub_request(:get, expected_url).to_return(:status => '404')
+      stub_request(:get, expected_url).to_return(status: "404")
 
       assert_raises(Slimmer::TemplateNotFoundException) do
-        skin.template 'example'
+        skin.template "example"
       end
     end
 
@@ -50,7 +49,7 @@ describe Slimmer::Skin do
       stub_request(:get, expected_url).to_raise(Errno::ECONNREFUSED)
 
       assert_raises(Slimmer::CouldNotRetrieveTemplate) do
-        skin.template 'example'
+        skin.template "example"
       end
     end
 
@@ -61,7 +60,7 @@ describe Slimmer::Skin do
       stub_request(:get, expected_url).to_raise(SocketError)
 
       assert_raises(Slimmer::CouldNotRetrieveTemplate) do
-        skin.template 'example'
+        skin.template "example"
       end
     end
 
@@ -72,7 +71,7 @@ describe Slimmer::Skin do
       stub_request(:get, expected_url).to_raise(OpenSSL::SSL::SSLError)
 
       assert_raises(Slimmer::CouldNotRetrieveTemplate) do
-        skin.template 'example'
+        skin.template "example"
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require "minitest/autorun"
 require "rack/test"
 require "json"
 require "logger"
-require "mocha/setup"
+require "mocha/minitest"
 require "timecop"
 
 MiniTest::Test.class_eval do

--- a/test/test_template_dependency_on_static_test.rb
+++ b/test/test_template_dependency_on_static_test.rb
@@ -2,13 +2,14 @@ require "test_helper"
 
 class TestTemplateDependencyOnStaticTest < MiniTest::Test
   def test_scripts_on_static_referenced_in_test_templates_exist
-    template_path = File.dirname(__FILE__).gsub('/test', '/lib/slimmer/test_templates')
-    Dir.foreach(template_path) do | template_file_name |
-      next if ['.','..'].include? template_file_name
+    template_path = File.dirname(__FILE__).gsub("/test", "/lib/slimmer/test_templates")
+    Dir.foreach(template_path) do |template_file_name|
+      next if [".", ".."].include? template_file_name
+
       doc = Nokogiri::HTML.fragment(File.read(File.join(template_path, template_file_name)))
       scripts = doc.search("script[src]").map { |node| node.attributes["src"].value }
       failing_scripts = allowing_real_web_connections do
-        scripts.select do |script_src|
+        scripts.reject do |script_src|
           uri = URI.parse(script_src)
           http = Net::HTTP.new(uri.host, uri.port)
           if uri.scheme == "https"
@@ -16,7 +17,7 @@ class TestTemplateDependencyOnStaticTest < MiniTest::Test
             http.verify_mode = OpenSSL::SSL::VERIFY_NONE
           end
           response = http.get(uri.request_uri)
-          response.code != "200"
+          response.code == "200"
         end
       end
       assert failing_scripts.empty?, "Some scripts could not be loaded: #{failing_scripts.inspect}"


### PR DESCRIPTION
- Fix deprecation warnings
- Migrate to `rubocop-govuk`

See commit messages for more detail.

Trello card: https://trello.com/c/Ik7ulDXQ/1768-3-upgrade-info-frontend-to-rails-6