### PR TITLE
Fix bug where parent_name was called without app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Fix bug where parent_name was called without app
+
 # 13.2.1
 
 * Fix deprecation warning: `Module#parent_name` has been renamed to

--- a/lib/slimmer/railtie.rb
+++ b/lib/slimmer/railtie.rb
@@ -4,18 +4,15 @@ module Slimmer
 
     initializer "slimmer.configure" do |app|
       slimmer_config = app.config.slimmer.to_hash
-
-      app_name = ENV["GOVUK_APP_NAME"] || module_parent_name
+      app_name = ENV["GOVUK_APP_NAME"] || Slimmer::Railtie.parent_name(app)
       slimmer_config = slimmer_config.reverse_merge(app_name: app_name)
 
       app.middleware.use Slimmer::App, slimmer_config
     end
 
-  private
-
     # TODO: remove this method when all our apps are in rails 6 and substitute
     # it with: app_name = ENV['GOVUK_APP_NAME'] || app.class.module_parent_name
-    def module_parent_name
+    def self.parent_name(app)
       if app.class.respond_to?(:module_parent_name)
         app.class.module_parent_name
       else

--- a/slimmer.gemspec
+++ b/slimmer.gemspec
@@ -27,11 +27,13 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency "minitest", "~> 5.4"
   s.add_development_dependency "mocha", "~> 1.1"
   s.add_development_dependency "rack-test", "~> 0.6.1"
+  s.add_development_dependency "rails", "~> 6.0.2"
   s.add_development_dependency "rake", "~> 0.9.2.2"
   s.add_development_dependency "rubocop-govuk", "~> 2.0.0"
   s.add_development_dependency "timecop", "~> 0.5.1"
   s.add_development_dependency "webmock", "3.5.0"
   s.add_development_dependency "yard", "0.8.7.6"
+
   s.files = Dir[
     "README.md",
     "CHANGELOG.md",

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -1,0 +1,35 @@
+require_relative "test_helper"
+
+describe Slimmer::Railtie do
+  let(:app1) { TestApp1::Application }
+  let(:app2) { TestApp2::Application }
+
+  after { ENV["GOVUK_APP_NAME"] = nil }
+
+  it "gets the app name from env when the app name is set in the environment" do
+    # set the app name in the environment
+    ENV["GOVUK_APP_NAME"] = "TestApp1"
+    # run app using slimmer initializer
+    Slimmer::Railtie.initializers.first.run(app1)
+
+    # check that slimmer initializer sets the correct app name in config from environment
+    assert_equal app1.middleware.use.first, [:use, [Slimmer::App, { app_name: "TestApp1" }], nil]
+  end
+
+  it "gets the app name from module_parent_name when the app name is not set in the environment" do
+    # make sure environment does not contain app name
+    ENV["GOVUK_APP_NAME"] = nil
+
+    # set mock to return app name
+    klass = MiniTest::Mock.new
+    klass.expect :module_parent_name, "TestApp2"
+
+    # run the test stubbing out the app name
+    TestApp2::Application.stub :class, klass do
+      # run app using slimmer initializer
+      Slimmer::Railtie.initializers.first.run(app2)
+      # check that slimmer initializer sets the correct app name in config from the app parent_name
+      assert_equal app2.middleware.use.first, [:use, [Slimmer::App, { app_name: "TestApp2" }], nil]
+    end
+  end
+end

--- a/test/test_apps/test_apps.rb
+++ b/test/test_apps/test_apps.rb
@@ -1,0 +1,18 @@
+require "rails"
+require "action_controller/railtie"
+
+module Rails
+  def self.cache
+    Slimmer::NoCache.new
+  end
+end
+
+module TestApp1
+  class Application < Rails::Application
+  end
+end
+
+module TestApp2
+  class Application < Rails::Application
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require "json"
 require "logger"
 require "mocha/minitest"
 require "timecop"
+require "test_apps/test_apps"
 
 MiniTest::Test.class_eval do
   def as_nokogiri(html_string)


### PR DESCRIPTION
The method parent_name in Railtie was allowed to be called without an
argument. This commit adds the argument `app` and adds a test to ensure
the argument is not removed in future.

Trello card: https://trello.com/c/Ik7ulDXQ/1768-3-upgrade-frontend-to-rails-6

Co-Authored-By: Rebecca Pearce <rebecca.pearce@digital.cabinet-office.gov.uk>
Co-Authored-By: Alan Gabbianelli <alan.gabbianelli@digital.cabinet-office.gov.uk>