### PR TITLE
Add header flag to allow custom error responses

### DIFF
--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -64,6 +64,10 @@ module Slimmer
       !!response.headers[Headers::SKIP_HEADER]
     end
 
+    def ignore_error_header?(response)
+      !!response.headers[Headers::IGNORE_ERROR_HEADER]
+    end
+
     def s(body)
       return body.to_s unless body.respond_to?(:each)
 
@@ -84,24 +88,30 @@ module Slimmer
       # Store the request id so it can be passed on with any template requests
       GovukRequestId.value = env["HTTP_GOVUK_REQUEST_ID"]
 
-      rewritten_body = case response.status
-                       when 200
-                         @skin.success request, response, s(response.body)
-                       when 403
-                         @skin.error "403", s(response.body), request.env
-                       when 404
-                         @skin.error "404", s(response.body), request.env
-                       when 410
-                         @skin.error "410", s(response.body), request.env
-                       else
-                         @skin.error "500", s(response.body), request.env
-                       end
+      body = rewritten_body(request, response)
 
-      rewritten_body = [rewritten_body] unless rewritten_body.respond_to?(:each)
-      response.body = rewritten_body
+      body = [body] unless body.respond_to?(:each)
+      response.body = body
       response.headers["Content-Length"] = content_length(response.body)
 
       response.finish
+    end
+
+    def rewritten_body(request, response)
+      return @skin.success request, response, s(response.body) if ignore_error_header?(response)
+
+      case response.status
+      when 200
+        @skin.success request, response, s(response.body)
+      when 403
+        @skin.error "403", s(response.body), request.env
+      when 404
+        @skin.error "404", s(response.body), request.env
+      when 410
+        @skin.error "410", s(response.body), request.env
+      else
+        @skin.error "500", s(response.body), request.env
+      end
     end
 
     def strip_slimmer_headers(headers)

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -20,6 +20,7 @@ module Slimmer
       skip:                 "Skip",
       template:             "Template",
       remove_search:        "Remove-Search",
+      ignore_error:         "Ignore-Error",
     }.freeze
 
     # @private
@@ -55,10 +56,15 @@ module Slimmer
     # @private
     REMOVE_SEARCH_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_search]}".freeze
 
+    # @private
+    IGNORE_ERROR_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:ignore_error]}".freeze
+
+
     # Set the "slimmer headers" to configure the page
     #
     # @param hash [Hash] the options
     # @option hash [String] application_name
+    # @option hash [String] ignore_error
     # @option hash [String] format
     # @option hash [String] organisations
     # @option hash [String] page_owner

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,6 +84,7 @@ class SlimmerIntegrationTest < MiniTest::Test
 
     template_name = case code
                     when 200 then "core_layout"
+                    when 422 then "core_layout"
                     when 404 then "404"
                     when 410 then "410"
                     else          "500"

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -295,6 +295,27 @@ module TypicalUsage
     end
   end
 
+  class IgnoreErrorTest < SlimmerIntegrationTest
+    given_response 422, %{
+      <html>
+      <head><title>422 Session expired</title>
+      <meta name="something" content="yes">
+      <script src="blah.js"></script>
+      <link href="app.css" rel="stylesheet" type="text/css">
+      </head>
+      <body class="body_class">
+      <div id="wrapper"><p class='message'>Your session expired</p></div>
+      </body>
+      </html>
+      <html>
+    }, "X-Slimmer-Ignore-Error" => "true"
+
+
+    def test_should_include_the_existing_error_message
+      assert_rendered_in_template "p.message", /^Your session expired/
+    end
+  end
+
   class ArbitraryWrapperIdTest < SlimmerIntegrationTest
     given_response 200, %{
       <html>


### PR DESCRIPTION
Currently for all non-200 pages, Slimmer will replace the response body with templates from Static. This certain apps like email-alert-frontend need to present custom error page (e.g. 422). This allows an app to tell Slimmer not to override the error page with the one in Static.

The host app just needs to set the header `X-Slimmer-Ignore-Error: true`