### PR TITLE
Revert "Add header flag to prevent overriding error responses"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 13.4.0
+
+* Revert X-Slimmer-Ignore-Error header (#246)
+
 # 13.3.0
 
 * Add X-Slimmer-Ignore-Error header flag to prevent overriding non-200 status responses

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -20,7 +20,6 @@ module Slimmer
       skip:                 "Skip",
       template:             "Template",
       remove_search:        "Remove-Search",
-      ignore_error:         "Ignore-Error",
     }.freeze
 
     # @private
@@ -56,15 +55,10 @@ module Slimmer
     # @private
     REMOVE_SEARCH_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_search]}".freeze
 
-    # @private
-    IGNORE_ERROR_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:ignore_error]}".freeze
-
-
     # Set the "slimmer headers" to configure the page
     #
     # @param hash [Hash] the options
     # @option hash [String] application_name
-    # @option hash [String] ignore_error
     # @option hash [String] format
     # @option hash [String] organisations
     # @option hash [String] page_owner

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "13.3.0".freeze
+  VERSION = "13.4.0".freeze
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,7 +84,6 @@ class SlimmerIntegrationTest < MiniTest::Test
 
     template_name = case code
                     when 200 then "core_layout"
-                    when 422 then "core_layout"
                     when 404 then "404"
                     when 410 then "410"
                     else          "500"

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -295,27 +295,6 @@ module TypicalUsage
     end
   end
 
-  class IgnoreErrorTest < SlimmerIntegrationTest
-    given_response 422, %{
-      <html>
-      <head><title>422 Session expired</title>
-      <meta name="something" content="yes">
-      <script src="blah.js"></script>
-      <link href="app.css" rel="stylesheet" type="text/css">
-      </head>
-      <body class="body_class">
-      <div id="wrapper"><p class='message'>Your session expired</p></div>
-      </body>
-      </html>
-      <html>
-    }, "X-Slimmer-Ignore-Error" => "true"
-
-
-    def test_should_include_the_existing_error_message
-      assert_rendered_in_template "p.message", /^Your session expired/
-    end
-  end
-
   class ArbitraryWrapperIdTest < SlimmerIntegrationTest
     given_response 200, %{
       <html>


### PR DESCRIPTION
https://trello.com/c/Uzpw1bDA/243-document-how-error-pages-work-on-govuk

Depends on: https://github.com/alphagov/email-alert-frontend/pull/774

This reverts commit 4a5172abbbeaa38b1985d46e755b78e70494253e.

Previously we added this header to support custom error page for a
specific error code, which wasn't handled by our infrastructure.
Since then, we've upgraded our infrastructure to provide a suitable
fallback that makes this change obsolete.

Although we may still need our apps to show more contextual error
responses, the general way we handle errors in our infrastructure
means all of these will need to be returned as 200 responses, to
avoid getting override downstream.