### PR TITLE
Add base tag into the head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add `<base>` tag into the `<head>`.
+
 # 15.0.0
 
 * BREAKING: Test templates no longer embed links to production JavaScript files,

--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -5,6 +5,7 @@ module Slimmer::Processors
       move_tags(src, dest, "link",   must_have: %w[href])
       move_tags(src, dest, "meta",   must_have: %w[name content], keys: %w[name content http-equiv], insertion_location: :top)
       move_tags(src, dest, "meta",   must_have: %w[property content], keys: %w[property content], insertion_location: :top)
+      move_tags(src, dest, "base",   must_have: %w[href])
     end
 
     def include_tag?(node, min_attrs)

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -17,6 +17,8 @@ class TagMoverTest < MiniTest::Test
           <meta property="p:empty" />
           <meta property="p:duplicate" content="name and content" />
           <meta property="og:image" content="custom-og-image" />
+          <base href="http://www.example.com/">
+          <base target="_self">
         </head>
         <body class="mainstream">
           <div id="wrapper"></div>
@@ -95,5 +97,13 @@ class TagMoverTest < MiniTest::Test
 
   def test_should_ignore_meta_tags_with_property_already_in_the_destination_with_the_same_name_and_content
     assert @template.css("meta[property='p:duplicate'][content='name and content']").length == 1, "Expected there to only be one duplicate=name and content meta (property) tag."
+  end
+
+  def test_should_move_base_tag_with_href_into_the_head
+    assert_in @template, "base[href='http://www.example.com/']", nil, "Should have moved the base tag"
+  end
+
+  def test_should_ignore_base_tag_with_target_but_no_href
+    assert_not_in @template, "base[target='_self']"
   end
 end


### PR DESCRIPTION
This PR adds the `<base>` tag into the `<head>`. This change supports an upcoming change to Whitehall which specifies the `<base>` tag for the CSV preview endpoint to fix a long-standing issue with broken links in the footer pointing to the wrong website root.