### PR TITLE
Amend toggle button selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Amend toggle button selector (#251)
+
 # 15.1.0
 
 * Add `<base>` tag into the `<head>`.

--- a/lib/slimmer/processors/search_remover.rb
+++ b/lib/slimmer/processors/search_remover.rb
@@ -9,7 +9,7 @@ module Slimmer::Processors
         search = dest.at_css("#global-header #search")
         search.remove if search
 
-        search_link = dest.at_css("#global-header a[href='#search']")
+        search_link = dest.at_css("#global-header .search-toggle")
         search_link.remove if search_link
       end
     end

--- a/test/processors/search_remover_test.rb
+++ b/test/processors/search_remover_test.rb
@@ -9,7 +9,7 @@ class SearchRemoverTest < MiniTest::Test
         </head>
         <body>
           <div id='global-header'>
-            <a href='#search'></a>
+            <button class='search-toggle'></button>
             <div id='search'></div>
           </div>
           <div id='search'></div>
@@ -43,7 +43,7 @@ class SearchRemoverTest < MiniTest::Test
       headers,
     ).filter(nil, @template)
 
-    assert_not_in @template, "#global-header a[href='#search']"
+    assert_not_in @template, "#global-header .search-toggle"
   end
 
   def test_should_not_remove_search_link_from_template_if_header_is_not_set
@@ -52,6 +52,6 @@ class SearchRemoverTest < MiniTest::Test
       headers,
     ).filter(nil, @template)
 
-    assert_in @template, "#global-header a[href='#search']"
+    assert_in @template, "#global-header .search-toggle"
   end
 end


### PR DESCRIPTION
The code in `search_remover.rb` assumes that the search toggle button is a
link.

This is an issue as work is being done to change the markup of this
button for accessibility purposes.

Change the search toggle button selector to a class selector instead to
ensure that functionality is preserved when we change the anchor tag to
a button tag.

https://trello.com/c/WLq4rKrW