### PR TITLE
Add an "AccountsShower" processor to show / hide accounts headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add X-Slimmer-Show-Accounts header to choose between accounts
+  header components. (#255)
 * Update to Ruby 2.7.2. (#254)
 
 # 15.1.1

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -28,6 +28,7 @@ module Slimmer
   autoload :HTTPClient, "slimmer/http_client"
 
   module Processors
+    autoload :AccountsShower, "slimmer/processors/accounts_shower"
     autoload :BodyClassCopier, "slimmer/processors/body_class_copier"
     autoload :BodyInserter, "slimmer/processors/body_inserter"
     autoload :ConditionalCommentMover, "slimmer/processors/conditional_comment_mover"

--- a/lib/slimmer/headers.rb
+++ b/lib/slimmer/headers.rb
@@ -20,6 +20,7 @@ module Slimmer
       skip: "Skip",
       template: "Template",
       remove_search: "Remove-Search",
+      show_accounts: "Show-Accounts",
     }.freeze
 
     # @private
@@ -55,6 +56,9 @@ module Slimmer
     # @private
     REMOVE_SEARCH_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:remove_search]}".freeze
 
+    # @private
+    SHOW_ACCOUNTS_HEADER = "#{HEADER_PREFIX}-#{SLIMMER_HEADER_MAPPING[:show_accounts]}".freeze
+
     # Set the "slimmer headers" to configure the page
     #
     # @param hash [Hash] the options
@@ -66,6 +70,7 @@ module Slimmer
     # @option hash [String] result_count
     # @option hash [String] search_parameters
     # @option hash [String] section
+    # @option hash [String] show_accounts
     # @option hash [String] skip
     # @option hash [String] template
     # @option hash [String] world_locations

--- a/lib/slimmer/processors/accounts_shower.rb
+++ b/lib/slimmer/processors/accounts_shower.rb
@@ -1,0 +1,29 @@
+module Slimmer::Processors
+  class AccountsShower
+    def initialize(headers)
+      @headers = headers
+    end
+
+    def filter(_src, dest)
+      header_value = @headers[Slimmer::Headers::SHOW_ACCOUNTS_HEADER]
+      if header_value == "signed-in"
+        remove_signed_out(dest)
+      elsif header_value == "signed-out"
+        remove_signed_in(dest)
+      else
+        remove_signed_out(dest)
+        remove_signed_in(dest)
+      end
+    end
+
+    def remove_signed_out(dest)
+      signed_out = dest.at_css("#global-header #accounts-signed-out")
+      signed_out.remove if signed_out
+    end
+
+    def remove_signed_in(dest)
+      signed_in = dest.at_css("#global-header #accounts-signed-in")
+      signed_in.remove if signed_in
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -107,6 +107,7 @@ module Slimmer
         Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
         Processors::SearchRemover.new(response.headers),
+        Processors::AccountsShower.new(response.headers),
       ]
 
       template_name = response.headers[Headers::TEMPLATE_HEADER] || "core_layout"

--- a/test/processors/accounts_shower_test.rb
+++ b/test/processors/accounts_shower_test.rb
@@ -1,0 +1,57 @@
+require_relative "../test_helper"
+
+class AccountsShowerTest < MiniTest::Test
+  def setup
+    super
+    @template = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <div id='global-header'>
+            <div id='accounts-signed-out'></div>
+            <div id='accounts-signed-in'></div>
+          </div>
+          <div id='accounts-signed-out'></div>
+          <div id='accounts-signed-in'></div>
+        </body>
+      </html>
+    )
+  end
+
+  def test_should_remove_accounts_from_template_if_header_is_not_set
+    headers = {}
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_not_in @template, "#global-header #accounts-signed-out"
+    assert_not_in @template, "#global-header #accounts-signed-in"
+    assert_in @template, "#accounts-signed-out"
+    assert_in @template, "#accounts-signed-in"
+  end
+
+  def test_should_remove_signed_out_from_template_if_header_is_signed_in
+    headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in" }
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_not_in @template, "#global-header #accounts-signed-out"
+    assert_in @template, "#global-header #accounts-signed-in"
+    assert_in @template, "#accounts-signed-out"
+    assert_in @template, "#accounts-signed-in"
+  end
+
+  def test_should_remove_signed_in_from_template_if_header_is_signed_out
+    headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out" }
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @template)
+
+    assert_in @template, "#global-header #accounts-signed-out"
+    assert_not_in @template, "#global-header #accounts-signed-in"
+    assert_in @template, "#accounts-signed-out"
+    assert_in @template, "#accounts-signed-in"
+  end
+end


### PR DESCRIPTION
The new show_accounts header has three states:

- "signed-in": remove the signed-out header
- "signed-out": remove the signed-in header
- anything else: remove both headers

I went for "Shower" over "Remover" because this has the opposite
behaviour to the SearchRemover: it removes the thing by default,
because we're only showing this header on a few pages.

---

[Trello card](https://trello.com/c/vdZrgBRy/363-make-changes-to-transition-for-trial-launch)