### PR TITLE
Prepare to ignore intermittent errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 15.3.0
+
+* Introduce separate, internal exception class for intermittent
+template retrieval errors.
+
 # 15.2.0
 
 * Add X-Slimmer-Show-Accounts header to choose between accounts

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -47,4 +47,5 @@ module Slimmer
 
   class TemplateNotFoundException < StandardError; end
   class CouldNotRetrieveTemplate < StandardError; end
+  class IntermittentRetrievalError < StandardError; end
 end

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -45,7 +45,7 @@ module Slimmer
     autoload :TitleInserter, "slimmer/processors/title_inserter"
   end
 
-  class TemplateNotFoundException < StandardError; end
   class CouldNotRetrieveTemplate < StandardError; end
-  class IntermittentRetrievalError < StandardError; end
+  class TemplateNotFoundException < CouldNotRetrieveTemplate; end
+  class IntermittentRetrievalError < CouldNotRetrieveTemplate; end
 end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -27,6 +27,10 @@ module Slimmer
         raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
       end
 
+      if e.is_a?(RestClient::Exception) && [502, 503, 504].include?(e.http_code)
+        raise IntermittentRetrievalError, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+      end
+
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     end
 

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -22,9 +22,11 @@ module Slimmer
     def load_template(template_name)
       url = template_url(template_name)
       HTTPClient.get(url)
-    rescue RestClient::Exception => e
-      raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
-    rescue Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError => e
+    rescue Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError, RestClient::Exception => e
+      if e.is_a?(RestClient::Exception) && e.http_code == 404
+        raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+      end
+
       raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
     end
 

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -23,15 +23,17 @@ module Slimmer
       url = template_url(template_name)
       HTTPClient.get(url)
     rescue Errno::ECONNREFUSED, SocketError, OpenSSL::SSL::SSLError, RestClient::Exception => e
+      message = "Unable to fetch: '#{template_name}' from '#{url}' because #{e}"
+
       if e.is_a?(RestClient::Exception) && e.http_code == 404
-        raise TemplateNotFoundException, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+        raise TemplateNotFoundException, message, caller
       end
 
       if e.is_a?(RestClient::Exception) && [502, 503, 504].include?(e.http_code)
-        raise IntermittentRetrievalError, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+        raise IntermittentRetrievalError, message, caller
       end
 
-      raise CouldNotRetrieveTemplate, "Unable to fetch: '#{template_name}' from '#{url}' because #{e}", caller
+      raise CouldNotRetrieveTemplate, message, caller
     end
 
     def template_url(template_name)

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "15.2.0".freeze
+  VERSION = "15.3.0".freeze
 end

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -35,7 +35,7 @@ describe Slimmer::Skin do
       skin = Slimmer::Skin.new asset_host: "http://example.local/"
 
       expected_url = "http://example.local/templates/example.html.erb"
-      stub_request(:get, expected_url).to_return(status: "404")
+      stub_request(:get, expected_url).to_return(status: 404)
 
       assert_raises(Slimmer::TemplateNotFoundException) do
         skin.template "example"

--- a/test/skin_test.rb
+++ b/test/skin_test.rb
@@ -42,6 +42,17 @@ describe Slimmer::Skin do
       end
     end
 
+    it "should raise appropriate exception for intermittent errors" do
+      skin = Slimmer::Skin.new asset_host: "http://example.local/"
+
+      expected_url = "http://example.local/templates/example.html.erb"
+      stub_request(:get, expected_url).to_return(status: 504)
+
+      assert_raises(Slimmer::IntermittentRetrievalError) do
+        skin.template "example"
+      end
+    end
+
     it "should raise appropriate exception when cant reach template host" do
       skin = Slimmer::Skin.new asset_host: "http://example.local/"
 


### PR DESCRIPTION
https://trello.com/c/qqGgd6mA/598-dev-pain-slimmer-causes-500-errors-for-transient-communication-errors-with-static

This separates certain kinds of unactionable exception
into a new, custom error, so that we can ignore them in
Sentry, much like we do for GDS API Adapters.

Before ignoring the errors, I also looked at whether we
could stop them from occurring in the first place, but
decided against making any changes:

- The local caching is deliberately short-lived, to avoid
false negative checks during deployment [1].

- The default timeouts are all 60 seconds [2], which is way
above what we have for GDS API Adapters.

Please see the commits for more details.

[1]: https://github.com/alphagov/slimmer/commit/b5f5b883500a3407eca10ec15b9068e075bf67fd
[2]: https://github.com/rest-client/rest-client#timeouts