### PR TITLE
Ensure async and defer scripts are hoisted to the top of the head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 15.4.0
+
+* Hoist `<async>` and `<defer>` JS Script tags to `<head>`. (#261)
+
 # 15.3.0
 
 * Introduce separate, internal exception class for intermittent

--- a/lib/slimmer/processors/tag_mover.rb
+++ b/lib/slimmer/processors/tag_mover.rb
@@ -1,11 +1,11 @@
 module Slimmer::Processors
   class TagMover
     def filter(src, dest)
-      move_tags(src, dest, "script", dest_node: "body", keys: %w[src inner_html])
       move_tags(src, dest, "link",   must_have: %w[href])
       move_tags(src, dest, "meta",   must_have: %w[name content], keys: %w[name content http-equiv], insertion_location: :top)
       move_tags(src, dest, "meta",   must_have: %w[property content], keys: %w[property content], insertion_location: :top)
       move_tags(src, dest, "base",   must_have: %w[href])
+      move_tags(src, dest, "script", keys: %w[src inner_html], head_if_attributes: %w[async defer])
     end
 
     def include_tag?(node, min_attrs)
@@ -31,21 +31,34 @@ module Slimmer::Processors
       node
     end
 
+    def head_or_body(node, head_if_attributes)
+      if head_if_attributes.any? { |attribute| node.has_attribute?(attribute) }
+        "head"
+      else
+        "body"
+      end
+    end
+
     def move_tags(src, dest, type, opts)
       comparison_attrs = opts[:keys] || opts[:must_have]
       min_attrs = opts[:must_have] || []
+      head_if_attributes = opts[:head_if_attributes] || []
+      dest_node = "head"
       already_there = dest.css(type).map { |node|
         tag_fingerprint(node, comparison_attrs)
       }.compact
-      dest_node = opts[:dest_node] || "head"
 
       src.css(type).each do |node|
         next unless include_tag?(node, min_attrs) && !already_there.include?(tag_fingerprint(node, comparison_attrs))
 
         node = wrap_node(src, node)
+        if head_if_attributes.any?
+          dest_node = head_or_body(node, head_if_attributes)
+          insert_at_top = true if dest_node == "head"
+        end
         node.remove
 
-        if opts[:insertion_location] == :top
+        if opts[:insertion_location] == :top || insert_at_top
           dest.at_xpath("/html/#{dest_node}").prepend_child(node)
         else
           dest.at_xpath("/html/#{dest_node}") << node

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "15.3.0".freeze
+  VERSION = "15.4.0".freeze
 end

--- a/test/processors/tag_mover_test.rb
+++ b/test/processors/tag_mover_test.rb
@@ -19,9 +19,13 @@ class TagMoverTest < MiniTest::Test
           <meta property="og:image" content="custom-og-image" />
           <base href="http://www.example.com/">
           <base target="_self">
-        </head>
-        <body class="mainstream">
+          <script async src="http://www.example.com/async_head.js"></script>
+          <script defer src="http://www.example.com/defer_head.js"></script>
+          </head>
+          <body class="mainstream">
           <div id="wrapper"></div>
+          <script async src="http://www.example.com/async_body.js"></script>
+          <script defer src="http://www.example.com/defer_body.js"></script>
           <script src="http://www.example.com/foo.js"></script>
           <script src="http://www.example.com/duplicate.js"></script>
         </body>
@@ -52,6 +56,17 @@ class TagMoverTest < MiniTest::Test
 
   def test_should_ignore_script_tags_already_in_the_destination_with_the_same_src_and_content
     assert @template.css("script[src='http://www.example.com/duplicate.js']").length == 1, "Expected there to only be one script tag with src 'http://www.example.com/duplicate.js'"
+  end
+
+  def test_should_move_async_and_defer_script_tags_into_the_head
+    assert_in @template, "head script[async][src='http://www.example.com/async_head.js']", nil, "Should have moved the script tag with attribute 'async' from head to head"
+    assert_in @template, "head script[defer][src='http://www.example.com/defer_head.js']", nil, "Should have moved the script tag with attribute 'defer' from head to head"
+    assert_in @template, "head script[async][src='http://www.example.com/async_body.js']", nil, "Should have moved the script tag with attribute 'async' from body to head"
+    assert_in @template, "head script[defer][src='http://www.example.com/defer_body.js']", nil, "Should have moved the script tag with attribute 'defer' from body to head"
+  end
+
+  def test_should_place_async_and_defer_script_tags_before_other_tags
+    assert @template.to_s.index("async_head.js") < @template.to_s.index("duplicate.css"), "Expected async_head.js to be before duplicate.css"
   end
 
   def test_should_place_source_script_tags_after_template_ones


### PR DESCRIPTION
Currently all script tags are moved to the bottom of the `body`.

It is  preferable, for `async` and `defer` script tags to be placed in the `head`, 
as their fetching and execution will not interfere with the parsing of the document.

Placing near the top of the head means their fetching can begin as soon as possible,
without waiting for other blocking tags such as CSS.

Scripts without `async` or `defer` attributes will continue to be placed at the bottom of the `body`.

[trello](https://trello.com/c/qUyucxL4/2296-5-support-async-and-defer-in-slimmer)