### PR TITLE
Add support for layout header component in static

### DIFF
--- a/lib/slimmer/processors/accounts_shower.rb
+++ b/lib/slimmer/processors/accounts_shower.rb
@@ -6,6 +6,14 @@ module Slimmer::Processors
 
     def filter(_src, dest)
       header_value = @headers[Slimmer::Headers::SHOW_ACCOUNTS_HEADER]
+      layout_header = dest.at_css(".gem-c-layout-header")
+      static_header = dest.at_css("#global-header")
+      if header_value && layout_header
+        static_header.remove if static_header
+      elsif !header_value
+        layout_header.remove if layout_header
+      end
+
       if header_value == "signed-in"
         remove_signed_out(dest)
       elsif header_value == "signed-out"
@@ -18,12 +26,22 @@ module Slimmer::Processors
 
     def remove_signed_out(dest)
       signed_out = dest.at_css("#global-header #accounts-signed-out")
+      signed_out_link = dest.css(".gem-c-layout-header [data-link-for='accounts-signed-out']")
+
       signed_out.remove if signed_out
+      signed_out_link.each do |link|
+        link.parent.remove
+      end
     end
 
     def remove_signed_in(dest)
       signed_in = dest.at_css("#global-header #accounts-signed-in")
+      signed_in_link = dest.css(".gem-c-layout-header [data-link-for='accounts-signed-in']")
+
       signed_in.remove if signed_in
+      signed_in_link.each do |link|
+        link.parent.remove
+      end
     end
   end
 end

--- a/test/processors/accounts_shower_test.rb
+++ b/test/processors/accounts_shower_test.rb
@@ -15,19 +15,17 @@ class AccountsShowerTest < MiniTest::Test
           <div id='accounts-signed-out'></div>
           <div id='accounts-signed-in'></div>
           <div class='gem-c-layout-header'>
-            <div class='govuk-header__navigation-container'>
-              <ul>
-                <li>
-                  <a data-link-for='accounts-signed-out'></a>
-                </li>
-                <li>
-                  <a data-link-for='accounts-signed-out'></a>
-                </li>
-                <li>
-                  <a data-link-for='accounts-signed-in'></a>
-                </li>
-              </ul>
-            </div>
+            <ul>
+              <li>
+                <a data-link-for='accounts-signed-out'></a>
+              </li>
+              <li>
+                <a data-link-for='accounts-signed-out'></a>
+              </li>
+              <li>
+                <a data-link-for='accounts-signed-in'></a>
+              </li>
+            </ul>
           </div>
         </body>
       </html>

--- a/test/processors/accounts_shower_test.rb
+++ b/test/processors/accounts_shower_test.rb
@@ -14,43 +14,62 @@ class AccountsShowerTest < MiniTest::Test
           </div>
           <div id='accounts-signed-out'></div>
           <div id='accounts-signed-in'></div>
+          <div class='gem-c-layout-header'>
+            <div class='govuk-header__navigation-container'>
+              <ul>
+                <li>
+                  <a data-link-for='accounts-signed-out'></a>
+                </li>
+                <li>
+                  <a data-link-for='accounts-signed-out'></a>
+                </li>
+                <li>
+                  <a data-link-for='accounts-signed-in'></a>
+                </li>
+              </ul>
+            </div>
+          </div>
         </body>
       </html>
     )
   end
 
-  def test_should_remove_accounts_from_template_if_header_is_not_set
+  def test_should_remove_accounts_and_layout_header_from_template_if_header_is_not_set
     headers = {}
     Slimmer::Processors::AccountsShower.new(
       headers,
     ).filter(nil, @template)
 
+    assert_not_in @template, ".gem-c-layout-header"
     assert_not_in @template, "#global-header #accounts-signed-out"
     assert_not_in @template, "#global-header #accounts-signed-in"
     assert_in @template, "#accounts-signed-out"
     assert_in @template, "#accounts-signed-in"
   end
 
-  def test_should_remove_signed_out_from_template_if_header_is_signed_in
+  def test_should_remove_global_header_and_signed_out_from_template_if_header_is_signed_in
     headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in" }
     Slimmer::Processors::AccountsShower.new(
       headers,
     ).filter(nil, @template)
 
-    assert_not_in @template, "#global-header #accounts-signed-out"
-    assert_in @template, "#global-header #accounts-signed-in"
+    assert_not_in @template, "#global-header"
+    assert_not_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+    assert_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
     assert_in @template, "#accounts-signed-out"
     assert_in @template, "#accounts-signed-in"
   end
 
-  def test_should_remove_signed_in_from_template_if_header_is_signed_out
+  def test_should_remove_global_header_and_signed_in_from_template_if_header_is_signed_out
     headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out" }
     Slimmer::Processors::AccountsShower.new(
       headers,
     ).filter(nil, @template)
 
-    assert_in @template, "#global-header #accounts-signed-out"
-    assert_not_in @template, "#global-header #accounts-signed-in"
+    assert_not_in @template, "#global-header"
+    assert_not_in @template, ".gem-c-layout-header #account-manager"
+    assert_not_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
     assert_in @template, "#accounts-signed-out"
     assert_in @template, "#accounts-signed-in"
   end


### PR DESCRIPTION
During development the markup for the account nav (appears on the transition page, and transition checker) was copied over from the layout header component instead of using the component itself. This was probably due to time constraints.

<img width="1048" alt="Screenshot 2021-02-02 at 18 30 08" src="https://user-images.githubusercontent.com/7116819/106645903-e959d880-6584-11eb-8028-7c2fa7feccde.png">


The component audits are complaining that we are including the assets for `layout_header` in static, when we are not using the component.

To fix this problem, we are removing the hard coded account navigation from static, and using the layout header component in its place:  https://github.com/alphagov/static/pull/2408

That is technically duplicating the header – these changes are here to conditionally swap the `#global-header` for the `layout_header` only when the account is enabled and the account nav should be present.



https://trello.com/c/9Kjy1hjb