### PR TITLE
Add compatibility for the public layout component

### DIFF
--- a/lib/slimmer/processors/accounts_shower.rb
+++ b/lib/slimmer/processors/accounts_shower.rb
@@ -8,9 +8,10 @@ module Slimmer::Processors
       header_value = @headers[Slimmer::Headers::SHOW_ACCOUNTS_HEADER]
       layout_header = dest.at_css(".gem-c-layout-header")
       static_header = dest.at_css("#global-header")
+
       if header_value && layout_header
         static_header.remove if static_header
-      elsif !header_value
+      elsif !header_value && !is_gem_layout?
         layout_header.remove if layout_header
       end
 
@@ -42,6 +43,12 @@ module Slimmer::Processors
       signed_in_link.each do |link|
         link.parent.remove
       end
+    end
+
+  private
+
+    def is_gem_layout?
+      @headers[Slimmer::Headers::TEMPLATE_HEADER]&.starts_with?("gem_layout")
     end
   end
 end

--- a/lib/slimmer/processors/search_remover.rb
+++ b/lib/slimmer/processors/search_remover.rb
@@ -11,6 +11,9 @@ module Slimmer::Processors
 
         search_link = dest.at_css("#global-header .search-toggle")
         search_link.remove if search_link
+
+        gem_search = dest.at_css(".gem-c-layout-header__search")
+        gem_search.remove if gem_search
       end
     end
   end

--- a/test/fixtures/gem_layout.html.erb
+++ b/test/fixtures/gem_layout.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+  <html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Gem layout</title>
+  </head>
+  <body class="gem-c-layout-for-public govuk-template__body">
+    <header class="gem-c-layout-header govuk-header" role="banner" data-module="govuk-header">
+      <p>This is the header</p>
+    </header>
+
+    <div id="wrapper">
+      <main class="govuk-main-wrapper" id="content">
+        <p>Lalalala, content.</p>
+      </main>
+    </div>
+
+    <footer class="gem-c-layout-footer govuk-footer" role="contentinfo">
+      <p>Some more information in the footer.</p>
+    </footer>
+  </body>
+</html>

--- a/test/processors/accounts_shower_test.rb
+++ b/test/processors/accounts_shower_test.rb
@@ -30,6 +30,28 @@ class AccountsShowerTest < MiniTest::Test
         </body>
       </html>
     )
+
+    @gem_template = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <header class='gem-c-layout-header'>
+            <ul>
+              <li>
+                <a data-link-for='accounts-signed-out'></a>
+              </li>
+              <li>
+                <a data-link-for='accounts-signed-out'></a>
+              </li>
+              <li>
+                <a data-link-for='accounts-signed-in'></a>
+              </li>
+            </ul>
+          </header>
+        </body>
+      </html>
+    )
   end
 
   def test_should_remove_accounts_and_layout_header_from_template_if_header_is_not_set
@@ -70,5 +92,47 @@ class AccountsShowerTest < MiniTest::Test
     assert_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
     assert_in @template, "#accounts-signed-out"
     assert_in @template, "#accounts-signed-in"
+  end
+
+  def test_should_remove_accounts_from_gem_template_if_header_is_not_set
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_in @gem_template, ".gem-c-layout-header"
+    assert_not_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+    assert_not_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+  end
+
+  def test_should_remove_signed_out_from_gem_template_if_header_is_signed_in
+    headers = {
+      Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in",
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_in @gem_template, ".gem-c-layout-header"
+    assert_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_not_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+  end
+
+  def test_should_signed_in_from_gem_template_if_header_is_signed_out
+    headers = {
+      Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out",
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_in @gem_template, ".gem-c-layout-header"
+    assert_not_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
   end
 end

--- a/test/processors/search_remover_test.rb
+++ b/test/processors/search_remover_test.rb
@@ -16,6 +16,17 @@ class SearchRemoverTest < MiniTest::Test
         </body>
       </html>
     )
+
+    @gem_template = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <div class="gem-c-layout-header__search">
+          </div>
+        </body>
+      </html>
+    )
   end
 
   def test_should_remove_search_from_template_if_header_is_set
@@ -53,5 +64,25 @@ class SearchRemoverTest < MiniTest::Test
     ).filter(nil, @template)
 
     assert_in @template, "#global-header .search-toggle"
+  end
+
+  def test_should_remove_search_from_gem_template_if_header_is_set
+    headers = {
+      Slimmer::Headers::REMOVE_SEARCH_HEADER => true,
+    }
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_not_in @gem_template, ".gem-c-layout-header__search"
+  end
+
+  def test_should_not_remove_search_from_gem_template_if_header_is_not_set
+    headers = {}
+    Slimmer::Processors::SearchRemover.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_in @gem_template, ".gem-c-layout-header__search"
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,7 +82,7 @@ class SlimmerIntegrationTest < MiniTest::Test
       end
     end
 
-    use_template("core_layout") if code == 200
+    use_templates if code == 200
     fetch_page
   end
 
@@ -90,10 +90,14 @@ class SlimmerIntegrationTest < MiniTest::Test
     get "/"
   end
 
-  def use_template(template_name)
-    template = File.read File.dirname(__FILE__) + "/fixtures/#{template_name}.html.erb"
-    stub_request(:get, "http://template.local/templates/#{template_name}.html.erb")
+  def use_templates
+    templates = %w[gem_layout core_layout]
+
+    templates.each do |template_name|
+      template = File.read File.dirname(__FILE__) + "/fixtures/#{template_name}.html.erb"
+      stub_request(:get, "http://template.local/templates/#{template_name}.html.erb")
       .to_return(body: template)
+    end
   end
 
 private


### PR DESCRIPTION
## What

Adds compatibility with the [public layout component][1] - allows search and the accounts links to be shown and hidden without removing other parts of the template.

## Why

Currently, the public layout component can't be used as a template. This is because Slimmer doesn't know which selectors to look for when removing aspects of the markup from the public layout component - search and navigation for example - which will be supplied by a new template in Static.

[1]: https://components.publishing.service.gov.uk/component-guide/layout_for_public