### PR TITLE
Update `gem_layout` template support

### DIFF
--- a/lib/slimmer/processors/accounts_shower.rb
+++ b/lib/slimmer/processors/accounts_shower.rb
@@ -23,7 +23,14 @@ module Slimmer::Processors
         remove_signed_out(dest)
         remove_signed_in(dest)
       end
+
+      if is_navigation_empty?(dest)
+        header_content = dest.at_css(".govuk-header__content")
+        header_content.remove if header_content
+      end
     end
+
+  private
 
     def remove_signed_out(dest)
       signed_out = dest.at_css("#global-header #accounts-signed-out")
@@ -45,7 +52,9 @@ module Slimmer::Processors
       end
     end
 
-  private
+    def is_navigation_empty?(dest)
+      dest.at_css(".govuk-header__navigation a").nil?
+    end
 
     def is_gem_layout?
       @headers[Slimmer::Headers::TEMPLATE_HEADER]&.starts_with?("gem_layout")

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -1,13 +1,28 @@
 module Slimmer::Processors
   class BodyInserter
-    def initialize(source_id = "wrapper", destination_id = "wrapper")
+    def initialize(source_id = "wrapper", destination_id = "wrapper", headers = {})
       @source_selector = "#" + source_id
       @destination_selector = "#" + destination_id
+      @headers = headers
     end
 
     def filter(src, dest)
-      body = Nokogiri::HTML.fragment(src.at_css(@source_selector).to_html)
+      source_markup = src.at_css(@source_selector)
+      destination_markup = dest.at_css(@destination_selector)
+
+      css_classes = []
+      css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
+      css_classes << destination_markup.attributes["class"].to_s.split(/ +/) if destination_markup.has_attribute?("class")
+
+      body = Nokogiri::HTML.fragment(source_markup.to_html)
       dest.at_css(@destination_selector).replace(body)
+      dest.at_css(@destination_selector).set_attribute("class", css_classes.flatten.uniq.join(" ")) if is_gem_layout? && css_classes.any?
+    end
+
+  private
+
+    def is_gem_layout?
+      @headers[Slimmer::Headers::TEMPLATE_HEADER]&.starts_with?("gem_layout")
     end
   end
 end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -101,13 +101,14 @@ module Slimmer
 
     def success(source_request, response, body)
       wrapper_id = options[:wrapper_id] || "wrapper"
+      template_wrapper_id = "wrapper" # All templates in Static use `#wrapper`
 
       processors = [
         Processors::TitleInserter.new,
         Processors::TagMover.new,
         Processors::NavigationMover.new(self),
         Processors::ConditionalCommentMover.new,
-        Processors::BodyInserter.new(wrapper_id),
+        Processors::BodyInserter.new(wrapper_id, template_wrapper_id, response.headers),
         Processors::BodyClassCopier.new,
         Processors::InsideHeaderInserter.new,
         Processors::HeaderContextInserter.new,

--- a/test/processors/accounts_shower_test.rb
+++ b/test/processors/accounts_shower_test.rb
@@ -37,17 +37,50 @@ class AccountsShowerTest < MiniTest::Test
         </head>
         <body>
           <header class='gem-c-layout-header'>
-            <ul>
-              <li>
-                <a data-link-for='accounts-signed-out'></a>
-              </li>
-              <li>
-                <a data-link-for='accounts-signed-out'></a>
-              </li>
-              <li>
-                <a data-link-for='accounts-signed-in'></a>
-              </li>
-            </ul>
+            <div class='govuk-header__content'>
+              <div class='govuk-header__navigation'>
+                <ul>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-in'></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </header>
+        </body>
+      </html>
+    )
+
+    @gem_template_with_extra_navigation = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <header class='gem-c-layout-header'>
+            <div class='govuk-header__content'>
+              <div class='govuk-header__navigation'>
+                <ul>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-in'></a>
+                  </li>
+                  <li>
+                    <a href='https://gov.uk/random'></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </header>
         </body>
       </html>
@@ -134,5 +167,64 @@ class AccountsShowerTest < MiniTest::Test
     assert_in @gem_template, ".gem-c-layout-header"
     assert_not_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
     assert_in @gem_template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+  end
+
+  def test_should_remove_navigation_if_navigation_empty
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template)
+
+    assert_in @gem_template, ".gem-c-layout-header"
+    assert_not_in @gem_template, ".govuk-header__content"
+  end
+
+  def test_should_remove_accounts_from_gem_template_if_header_is_not_set_but_leave_other_navigation
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template_with_extra_navigation)
+
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header"
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header a[href='https://gov.uk/random']"
+    assert_not_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+    assert_not_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+  end
+
+  def test_should_remove_signed_out_from_gem_template_if_header_is_signed_in_but_leave_other_navigation
+    headers = {
+      Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in",
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template_with_extra_navigation)
+
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header"
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header a[href='https://gov.uk/random']"
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_not_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+  end
+
+  def test_should_signed_in_from_gem_template_if_header_is_signed_out_but_leave_other_navigation
+    headers = {
+      Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out",
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::AccountsShower.new(
+      headers,
+    ).filter(nil, @gem_template_with_extra_navigation)
+
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header"
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header a[href='https://gov.uk/random']"
+    assert_not_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
   end
 end


### PR DESCRIPTION
## What

When using the `gem_layout` template in statice, fixes layout issue in the header and allows CSS classes on both `#wrapper` elements to be merged.

These are `gem_layout` template specific changes, so won't affect pages using the `core_layout` template to preserve backwards compatibility.

## Why

When the navigation links were removed in the gem layout it would leave the wrapping element. The wrapping element had padding set on it which would cause the layout to shift even if there were no child elements. This change removes the wrapping element if there are no navigation links.

The gem layout template has classes that are needed on the `#wrapper` element - these classes are lost when the `body_inserter` moves the element from the source into the template. This change merges the classes on both the template and source elements, de-dupes them, and adds them to the final rendered page.

## Visual changes

Before:

![image](https://user-images.githubusercontent.com/1732331/115901234-d30f3a80-a458-11eb-8c49-d26b0c1d1ffd.png)

Troublesome element highlighted in yellow:

![image](https://user-images.githubusercontent.com/1732331/115901350-f639ea00-a458-11eb-85b2-414861f79799.png)

After fix:
![image](https://user-images.githubusercontent.com/1732331/115901784-8d9f3d00-a459-11eb-88d6-f286f5b72033.png)




