### PR TITLE
[DO NOT MERGE] Changes to account_shower processor

### DIFF
--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -28,7 +28,7 @@ module Slimmer
   autoload :HTTPClient, "slimmer/http_client"
 
   module Processors
-    autoload :AccountsShower, "slimmer/processors/accounts_shower"
+    autoload :LayoutHeaderManager, "slimmer/processors/layout_header_manager"
     autoload :BodyClassCopier, "slimmer/processors/body_class_copier"
     autoload :BodyInserter, "slimmer/processors/body_inserter"
     autoload :ConditionalCommentMover, "slimmer/processors/conditional_comment_mover"

--- a/lib/slimmer/processors/layout_header_manager.rb
+++ b/lib/slimmer/processors/layout_header_manager.rb
@@ -1,12 +1,12 @@
 module Slimmer::Processors
-  class AccountsShower
+  class LayoutHeaderManager
     def initialize(headers)
       @headers = headers
     end
 
     def filter(_src, dest)
       header_value = @headers[Slimmer::Headers::SHOW_ACCOUNTS_HEADER]
-      layout_header = dest.at_css(".gem-c-layout-header")
+      layout_header = dest.xpath("//*[not (@id='wrapper')]/header[@class='gem-c-layout-header']")
       static_header = dest.at_css("#global-header")
 
       if header_value && layout_header
@@ -27,6 +27,15 @@ module Slimmer::Processors
       if is_navigation_empty?(dest)
         header_content = dest.at_css(".govuk-header__content")
         header_content.remove if header_content
+      end
+
+      if has_app_level_layout_header?(dest)
+        app_level_layout_header = dest.at_css("#wrapper .gem-c-layout-header")
+        layout = dest.at_css("body > .gem-c-layout-header")
+        static = dest.at_css("#global-header")
+
+        static.replace(app_level_layout_header) if static
+        layout.replace(app_level_layout_header) if layout
       end
     end
 
@@ -50,6 +59,10 @@ module Slimmer::Processors
       signed_in_link.each do |link|
         link.parent.remove
       end
+    end
+
+    def has_app_level_layout_header?(dest)
+      !dest.at_css("#wrapper .gem-c-layout-header").nil?
     end
 
     def is_navigation_empty?(dest)

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -116,7 +116,7 @@ module Slimmer
         Processors::SearchParameterInserter.new(response),
         Processors::SearchPathSetter.new(response),
         Processors::SearchRemover.new(response.headers),
-        Processors::AccountsShower.new(response.headers),
+        Processors::LayoutHeaderManager.new(response.headers),
       ]
 
       template_name = response.headers[Headers::TEMPLATE_HEADER] || "core_layout"

--- a/test/processors/layout_header_manager_test.rb
+++ b/test/processors/layout_header_manager_test.rb
@@ -1,6 +1,6 @@
 require_relative "../test_helper"
 
-class AccountsShowerTest < MiniTest::Test
+class LayoutHeaderManagerTest < MiniTest::Test
   def setup
     super
     @template = as_nokogiri %(
@@ -14,7 +14,7 @@ class AccountsShowerTest < MiniTest::Test
           </div>
           <div id='accounts-signed-out'></div>
           <div id='accounts-signed-in'></div>
-          <div class='gem-c-layout-header'>
+          <header class='gem-c-layout-header'>
             <ul>
               <li>
                 <a data-link-for='accounts-signed-out'></a>
@@ -26,6 +26,25 @@ class AccountsShowerTest < MiniTest::Test
                 <a data-link-for='accounts-signed-in'></a>
               </li>
             </ul>
+          </header>
+        </body>
+      </html>
+    )
+
+    @template_with_app_level_header_override = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <header id='global-header'>
+            <div class='govuk-header__content'>
+            </div>
+          </header>
+          <div id='wrapper'>
+            <header class='gem-c-layout-header gem-c-layout-header--i-am-more-important'>
+              <div class='govuk-header__content'>
+              </div>
+            </header>
           </div>
         </body>
       </html>
@@ -53,6 +72,45 @@ class AccountsShowerTest < MiniTest::Test
               </div>
             </div>
           </header>
+        </body>
+      </html>
+    )
+
+    @gem_template_with_app_level_header_override = as_nokogiri %(
+      <html>
+        <head>
+        </head>
+        <body>
+          <header class='gem-c-layout-header'>
+            <div class='govuk-header__content'>
+              <div class='govuk-header__navigation'>
+                <ul>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-out'></a>
+                  </li>
+                  <li>
+                    <a data-link-for='accounts-signed-in'></a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </header>
+          <div id='wrapper'>
+            <header class='gem-c-layout-header gem-c-layout-header--i-am-more-important'>
+              <div class='govuk-header__content'>
+                <div class='govuk-header__navigation'>
+                  <ul>
+                    <li>
+                      <a data-link-for='app-level'></a>
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </header>
+          </div>
         </body>
       </html>
     )
@@ -89,7 +147,7 @@ class AccountsShowerTest < MiniTest::Test
 
   def test_should_remove_accounts_and_layout_header_from_template_if_header_is_not_set
     headers = {}
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @template)
 
@@ -102,10 +160,9 @@ class AccountsShowerTest < MiniTest::Test
 
   def test_should_remove_global_header_and_signed_out_from_template_if_header_is_signed_in
     headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in" }
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @template)
-
     assert_not_in @template, "#global-header"
     assert_not_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
     assert_in @template, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
@@ -115,7 +172,7 @@ class AccountsShowerTest < MiniTest::Test
 
   def test_should_remove_global_header_and_signed_in_from_template_if_header_is_signed_out
     headers = { Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out" }
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @template)
 
@@ -132,7 +189,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
 
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template)
 
@@ -146,7 +203,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in",
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template)
 
@@ -160,7 +217,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-out",
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template)
 
@@ -174,7 +231,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
 
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template)
 
@@ -187,7 +244,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
 
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template_with_extra_navigation)
 
@@ -202,7 +259,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::SHOW_ACCOUNTS_HEADER => "signed-in",
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template_with_extra_navigation)
 
@@ -218,7 +275,7 @@ class AccountsShowerTest < MiniTest::Test
       Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
     }
 
-    Slimmer::Processors::AccountsShower.new(
+    Slimmer::Processors::LayoutHeaderManager.new(
       headers,
     ).filter(nil, @gem_template_with_extra_navigation)
 
@@ -226,5 +283,32 @@ class AccountsShowerTest < MiniTest::Test
     assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header a[href='https://gov.uk/random']"
     assert_not_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
     assert_in @gem_template_with_extra_navigation, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+  end
+
+  def test_should_replace_static_header_with_app_level_header_when_app_level_header_exists
+    headers = {}
+    Slimmer::Processors::LayoutHeaderManager.new(
+      headers,
+    ).filter(nil, @template_with_app_level_header_override)
+
+    assert_not_in @template_with_app_level_header_override, "#wrapper .gem-c-layout-header"
+    assert_not_in @template_with_app_level_header_override, "header#global-header"
+    assert_in @template_with_app_level_header_override, ".gem-c-layout-header.gem-c-layout-header--i-am-more-important"
+  end
+
+  def test_should_replace_gem_header_with_app_level_header_when_app_level_header_exists
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::LayoutHeaderManager.new(
+      headers,
+    ).filter(nil, @gem_template_with_app_level_header_override)
+
+    assert_in @gem_template_with_app_level_header_override, ".gem-c-layout-header--i-am-more-important"
+    assert_in @gem_template_with_app_level_header_override, ".gem-c-layout-header a[data-link-for='app-level']"
+    assert_not_in @gem_template_with_app_level_header_override, ".gem-c-layout-header [data-link-for='accounts-signed-out']"
+    assert_not_in @gem_template_with_app_level_header_override, ".gem-c-layout-header [data-link-for='accounts-signed-in']"
+    assert_not_in @gem_template_with_app_level_header_override, ".gem-c-layout-header:not(.gem-c-layout-header--i-am-more-important)"
   end
 end


### PR DESCRIPTION
https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page

The account manager uses a different site header from the rest of GOVUK. The main differences are:
- Has account navigation with the “account” link highlighted to indicate the user is currently viewing their account
- In addition to the GOVUK home link/logo we display the “Account” product name.
- The home link directs the user back to the account homepage (as opposed to other pages on GOVUK where the home link will link back to the GOVUK homepage)

This was no problem on `govuk-account-manager-prototype` as it has its own layout and does not use static or slimmer, so we simply called the component with the necessary parameters [on our application file](https://github.com/alphagov/govuk-account-manager-prototype/blob/7858b55afcddc2f855d909abd051838d95f21f13/app/views/layouts/application.html.erb#L64). 

However, we are now [working on migrating the account homepage](https://github.com/alphagov/frontend/compare/msw/account-home-page) to the `frontend` app. which uses `static` and `slimmer`. Much of the page structure, including the site header on pages rendered by `frontend`, comes from `static`. This is an issue as with our current setup can’t easily make this particular page in `frontend` use a custom layout header that is different from every other page rendered by this app. 

These changes introduce the ability to set a `layout_header` at the app level which will override the one in static. We could theoretically achieve the same thing by using slimmer headers, however I have gone this route as I thought it would be the  least spaghetti-esque option of the two. I stand to be corrected if there is an easier/better way.

Ah and I renamed `account_shower.rb` to `layout_header_manager.rb` as it does other things in addition to handling account-related logic.