### PR TITLE
Add feedback URL swapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Add feedback url swapper (#271)
+
 # 15.5.1
 * Update gem_layout template support (#267)
 

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -32,6 +32,7 @@ module Slimmer
     autoload :BodyClassCopier, "slimmer/processors/body_class_copier"
     autoload :BodyInserter, "slimmer/processors/body_inserter"
     autoload :ConditionalCommentMover, "slimmer/processors/conditional_comment_mover"
+    autoload :FeedbackURLSwapper, "slimmer/processors/feedback_url_swapper"
     autoload :MetadataInserter, "slimmer/processors/metadata_inserter"
     autoload :HeaderContextInserter, "slimmer/processors/header_context_inserter"
     autoload :InsideHeaderInserter, "slimmer/processors/inside_header_inserter"

--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -24,7 +24,7 @@ module Slimmer::Processors
     # need to be kept in sync.
     def remove_pii(string)
       email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-      string.gsub(email_regex, "[email]").force_encoding("UTF-8")
+      string.dup.force_encoding("UTF-8").gsub(email_regex, "[email]")
     end
 
     def is_gem_layout?

--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -1,28 +1,30 @@
 module Slimmer::Processors
   class FeedbackURLSwapper
-    def initialize(request, headers = {})
+    def initialize(request, headers)
       @headers = headers
       @request = request
     end
 
     def filter(_src, dest)
-      email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
+      return dest unless is_gem_layout?
 
-      original_url = @request.base_url + @request.fullpath
-      original_url_without_pii = utf_encode(original_url.gsub(email_regex, "[email]"))
-      dest.at_css(".gem-c-feedback input[name='url']").set_attribute("value", original_url_without_pii) if is_gem_layout?
+      original_url_without_pii = remove_pii(@request.base_url + @request.fullpath)
+      dest.at_css(".gem-c-feedback input[name='url']").set_attribute("value", original_url_without_pii)
 
-      full_path = @request.fullpath
-      full_path_without_pii = utf_encode(full_path.gsub(email_regex, "[email]"))
-      dest.at_css(".gem-c-feedback input[name='email_survey_signup[survey_source]']").set_attribute("value", full_path_without_pii) if is_gem_layout?
+      full_path_without_pii = remove_pii(@request.fullpath)
+      dest.at_css(".gem-c-feedback input[name='email_survey_signup[survey_source]']").set_attribute("value", full_path_without_pii)
 
       dest
     end
 
   private
 
-    def utf_encode(element)
-      element.is_a?(String) ? element.encode : element
+    # This PII removal is also found in the [feedback component in the GOV.UK
+    # Publishing Components gem](https://git.io/JcCIE), and any changes made
+    # need to be kept in sync.
+    def remove_pii(string)
+      email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
+      string.force_encoding("UTF-8").gsub(email_regex, "[email]")
     end
 
     def is_gem_layout?

--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -24,7 +24,7 @@ module Slimmer::Processors
     # need to be kept in sync.
     def remove_pii(string)
       email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-      string.force_encoding("UTF-8").gsub(email_regex, "[email]")
+      string.gsub(email_regex, "[email]")
     end
 
     def is_gem_layout?

--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -24,7 +24,7 @@ module Slimmer::Processors
     # need to be kept in sync.
     def remove_pii(string)
       email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
-      string.gsub(email_regex, "[email]")
+      string.gsub(email_regex, "[email]").force_encoding("UTF-8")
     end
 
     def is_gem_layout?

--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -1,0 +1,32 @@
+module Slimmer::Processors
+  class FeedbackURLSwapper
+    def initialize(request, headers = {})
+      @headers = headers
+      @request = request
+    end
+
+    def filter(_src, dest)
+      email_regex = /[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/
+
+      original_url = @request.base_url + @request.fullpath
+      original_url_without_pii = utf_encode(original_url.gsub(email_regex, "[email]"))
+      dest.at_css(".gem-c-feedback input[name='url']").set_attribute("value", original_url_without_pii) if is_gem_layout?
+
+      full_path = @request.fullpath
+      full_path_without_pii = utf_encode(full_path.gsub(email_regex, "[email]"))
+      dest.at_css(".gem-c-feedback input[name='email_survey_signup[survey_source]']").set_attribute("value", full_path_without_pii) if is_gem_layout?
+
+      dest
+    end
+
+  private
+
+    def utf_encode(element)
+      element.is_a?(String) ? element.encode : element
+    end
+
+    def is_gem_layout?
+      @headers[Slimmer::Headers::TEMPLATE_HEADER]&.starts_with?("gem_layout")
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -109,6 +109,7 @@ module Slimmer
         Processors::NavigationMover.new(self),
         Processors::ConditionalCommentMover.new,
         Processors::BodyInserter.new(wrapper_id, template_wrapper_id, response.headers),
+        Processors::FeedbackURLSwapper.new(source_request, response.headers),
         Processors::BodyClassCopier.new,
         Processors::InsideHeaderInserter.new,
         Processors::HeaderContextInserter.new,

--- a/test/processors/feedback_url_swapper_test.rb
+++ b/test/processors/feedback_url_swapper_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class FeedbackURLSwapperTest < MiniTest::Test
+  def test_should_replace_input_url_values_in_gem_layout
+    template = as_nokogiri %(
+      <html>
+        <body>
+          <div class="gem-c-feedback">
+            <input
+              id="test-input"
+              type="hidden"
+              name="email_survey_signup[survey_source]"
+              value="/old_path"
+            >
+            <input
+              id="test-input-two"
+              type="hidden"
+              name="url"
+              value="https://example.com/old_path"
+            >
+          </div>
+        </body>
+      </html>
+    )
+
+    request = {}
+
+    def request.base_url
+      "https://new-example.com"
+    end
+
+    def request.fullpath
+      "/new_path"
+    end
+
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
+    }
+
+    Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
+
+    assert_in template, "#test-input[value='/new_path']"
+    assert_in template, "#test-input-two[value='https://new-example.com/new_path']"
+  end
+
+  def test_should_not_replace_input_url_values_when_not_gem_layout
+    template = as_nokogiri %(
+      <html>
+        <body>
+          <div class="gem-c-feedback">
+            <input
+              id="test-input"
+              type="hidden"
+              name="email_survey_signup[survey_source]"
+              value="/old_path"
+            >
+            <input
+              id="test-input-two"
+              type="hidden"
+              name="url"
+              value="https://example.com/old_path"
+            >
+          </div>
+        </body>
+      </html>
+    )
+
+    request = {}
+
+    def request.base_url
+      "https://new-example.com"
+    end
+
+    def request.fullpath
+      "/new_path"
+    end
+
+    headers = {
+      Slimmer::Headers::TEMPLATE_HEADER => "core_layout",
+    }
+
+    Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
+
+    assert_in template, "#test-input[value='/old_path']"
+    assert_in template, "#test-input-two[value='https://example.com/old_path']"
+  end
+end

--- a/test/processors/feedback_url_swapper_test.rb
+++ b/test/processors/feedback_url_swapper_test.rb
@@ -23,19 +23,10 @@ class FeedbackURLSwapperTest < MiniTest::Test
       </html>
     )
 
-    request = {}
+    env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request = Rack::Request.new(env)
 
-    def request.base_url
-      "https://new-example.com"
-    end
-
-    def request.fullpath
-      "/new_path"
-    end
-
-    headers = {
-      Slimmer::Headers::TEMPLATE_HEADER => "gem_layout",
-    }
+    headers = { Slimmer::Headers::TEMPLATE_HEADER => "gem_layout" }
 
     Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
 
@@ -65,23 +56,77 @@ class FeedbackURLSwapperTest < MiniTest::Test
       </html>
     )
 
-    request = {}
+    env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request = Rack::Request.new(env)
 
-    def request.base_url
-      "https://new-example.com"
-    end
-
-    def request.fullpath
-      "/new_path"
-    end
-
-    headers = {
-      Slimmer::Headers::TEMPLATE_HEADER => "core_layout",
-    }
+    headers = { Slimmer::Headers::TEMPLATE_HEADER => "core_layout" }
 
     Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
 
     assert_in template, "#test-input[value='/old_path']"
     assert_in template, "#test-input-two[value='https://example.com/old_path']"
+  end
+
+  def test_should_redact_an_email_adress_in_the_url
+    template = as_nokogiri %(
+      <html>
+        <body>
+          <div class="gem-c-feedback">
+            <input
+              id="test-input"
+              type="hidden"
+              name="email_survey_signup[survey_source]"
+              value="/old_path"
+            >
+            <input
+              id="test-input-two"
+              type="hidden"
+              name="url"
+              value="https://example.com/old_path"
+            >
+          </div>
+        </body>
+      </html>
+    )
+
+    env = Rack::MockRequest.env_for("https://new-example.com/new_path?secret@email.com")
+    request = Rack::Request.new(env)
+
+    headers = { Slimmer::Headers::TEMPLATE_HEADER => "gem_layout" }
+
+    Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
+
+    assert_in template, "#test-input[value='/new_path?[email]']"
+    assert_in template, "#test-input-two[value='https://new-example.com/new_path?[email]']"
+  end
+
+  def test_should_cope_with_a_ascii_encoded_url
+    template = as_nokogiri %(
+      <div class="gem-c-feedback">
+        <input
+          id="test-input"
+          name="email_survey_signup[survey_source]"
+          value="/old_path"
+        >
+        <input
+          id="test-input-two"
+          name="url"
+          value="https://example.com/old_path"
+        >
+      </div>
+    )
+
+    # Need to use a stub as a MockRequest will throw an exception on ASCII
+    # characters.
+    request = stub("Rack::Request",
+                   base_url: "https://example.com".force_encoding("ASCII-8BIT"),
+                   fullpath: "/test?áscii=%EE%90%80".force_encoding("ASCII-8BIT"))
+
+    headers = { Slimmer::Headers::TEMPLATE_HEADER => "gem_layout" }
+
+    Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
+
+    assert_in template, "#test-input[value='/test?áscii=%EE%90%80']"
+    assert_in template, "#test-input-two[value='https://example.com/test?áscii=%EE%90%80']"
   end
 end


### PR DESCRIPTION
## What

Adds a processor that searches for the two hidden input elements that allow the feedback component to report the URL, and updates the value of the inputs to the current page URL.

## Why

The feedback component has two hidden fields that allow it to tie a piece of feedback to a particular page. When the feedback component was rendered by the frontend application it could correctly populate this field - but when the feedback component was moved to the template rendered by Static it incorrectly eported the current URL as being the template URL.

Since Static doesn't have access to the URL, it needs to be swapped in using Slimmer in the frontend application - this searches for the two hidden input fields and corrects the value to the current page URL.

Fixing this in Slimmer rather than in Static means less work when templates are fully rendered by the frontend applications.
