### PR TITLE
Use safe navigation operator in feedback url swapper

### DIFF
--- a/lib/slimmer/processors/feedback_url_swapper.rb
+++ b/lib/slimmer/processors/feedback_url_swapper.rb
@@ -9,10 +9,10 @@ module Slimmer::Processors
       return dest unless is_gem_layout?
 
       original_url_without_pii = remove_pii(@request.base_url + @request.fullpath)
-      dest.at_css(".gem-c-feedback input[name='url']").set_attribute("value", original_url_without_pii)
+      dest.at_css(".gem-c-feedback input[name='url']")&.set_attribute("value", original_url_without_pii)
 
       full_path_without_pii = remove_pii(@request.fullpath)
-      dest.at_css(".gem-c-feedback input[name='email_survey_signup[survey_source]']").set_attribute("value", full_path_without_pii)
+      dest.at_css(".gem-c-feedback input[name='email_survey_signup[survey_source]']")&.set_attribute("value", full_path_without_pii)
 
       dest
     end

--- a/test/processors/feedback_url_swapper_test.rb
+++ b/test/processors/feedback_url_swapper_test.rb
@@ -129,4 +129,32 @@ class FeedbackURLSwapperTest < MiniTest::Test
     assert_in template, "#test-input[value='/test?áscii=%EE%90%80']"
     assert_in template, "#test-input-two[value='https://example.com/test?áscii=%EE%90%80']"
   end
+
+  def test_should_cope_with_no_selector_being_found
+    template = as_nokogiri %(
+      <div>
+        <input
+          id="test-input"
+          name="NOT-email_survey_signup[survey_source]"
+          value="/old_path"
+        >
+        <input
+          id="test-input-two"
+          name="NOT-url"
+          value="https://example.com/old_path"
+        >
+      </div>
+    )
+
+    env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request = Rack::Request.new(env)
+
+    headers = { Slimmer::Headers::TEMPLATE_HEADER => "gem_layout" }
+
+    original_html = template.to_s
+
+    Slimmer::Processors::FeedbackURLSwapper.new(request, headers).filter(nil, template)
+
+    assert_equal original_html, template.to_s
+  end
 end


### PR DESCRIPTION
## What

Use the `&.` safe navigation operator in the feedback URL swapper.

Using `&.` is equivalent to `thing ? thing.some_method : thing` - so won't throw an error as `set_attribute` is not used.

## Why

This was causing lots of tests to fail because the HTML stubs for the tests didn't have the selector being searched for in them. This threw an error because `set_attribute` can't be used on nil.
