### PR TITLE
Resolve Nokogiri deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 16.0.1
+* Resolve Nokogiri deprecation warning (#277)
+
 # 16.0.0
 * BREAKING: Remove NavigationMover processor (#275)
 

--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -5,21 +5,21 @@ module Slimmer::Processors
       @app_name = app_name
     end
 
-    def filter(_src, dest)
-      head = dest.at_css("head")
+    def filter(_old_doc, new_doc)
+      head = new_doc.at_css("head")
 
-      add_meta_tag("analytics:organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head)
-      add_meta_tag("analytics:world-locations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head)
-      add_meta_tag("format", @headers[Slimmer::Headers::FORMAT_HEADER], head)
-      add_meta_tag("search-result-count", @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head)
-      add_meta_tag("rendering-application", @app_name, head)
+      add_meta_tag("analytics:organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head, new_doc)
+      add_meta_tag("analytics:world-locations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head, new_doc)
+      add_meta_tag("format", @headers[Slimmer::Headers::FORMAT_HEADER], head, new_doc)
+      add_meta_tag("search-result-count", @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head, new_doc)
+      add_meta_tag("rendering-application", @app_name, head, new_doc)
     end
 
   private
 
-    def add_meta_tag(name, content, head)
+    def add_meta_tag(name, content, head, doc)
       if content
-        meta_node = Nokogiri::XML::Node.new("meta", head)
+        meta_node = Nokogiri::XML::Node.new("meta", doc)
         meta_node["name"] = "govuk:#{name}"
         meta_node["content"] = content
 

--- a/lib/slimmer/processors/search_parameter_inserter.rb
+++ b/lib/slimmer/processors/search_parameter_inserter.rb
@@ -6,25 +6,25 @@ module Slimmer::Processors
       @response = response
     end
 
-    def filter(_content_document, page_template)
-      search_form = page_template.at_css("form#search")
+    def filter(_old_doc, new_doc)
+      search_form = new_doc.at_css("form#search")
       if search_parameters && search_form
         search_parameters.each_pair do |name, value|
           # Value can either be a string or an array of values
           if value.is_a? Array
             array_name = "#{name}[]"
             value.each do |array_value|
-              add_hidden_input(search_form, array_name, array_value)
+              add_hidden_input(search_form, array_name, array_value, new_doc)
             end
           else
-            add_hidden_input(search_form, name, value)
+            add_hidden_input(search_form, name, value, new_doc)
           end
         end
       end
     end
 
-    def add_hidden_input(search_form, name, value)
-      element = Nokogiri::XML::Node.new("input", search_form)
+    def add_hidden_input(search_form, name, value, doc)
+      element = Nokogiri::XML::Node.new("input", doc)
       element["type"] = "hidden"
       element["name"] = name
       element["value"] = value.to_s

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "16.0.0".freeze
+  VERSION = "16.0.1".freeze
 end


### PR DESCRIPTION
Nokogiri warning:

> warning: Passing a Node as the second parameter to Node.new is deprecated. Please pass a Document instead, or prefer an alternative constructor like Node#add_child. This will become an error in a future release of Nokogiri.

See 1.13.0 Nokogiri [deprecation notice](https://nokogiri.org/CHANGELOG.html#deprecated):

> Passing a Nokogiri::XML::Node as the second parameter to Node.new is deprecated and will generate a warning. This parameter should be a kind of Nokogiri::XML::Document. This will become an error in a future version of Nokogiri. [#975]