### PR TITLE
Add guidance about slimmer and before_actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ class ApplicationController < ActionController::Base
 end
 ```
 
+## Use in before_action renders
+
+If you have a non-default layout and want to render in a before_action method, note that you may have to explicitly call `slimmer_template(:your_template_name)` in the action before rendering. Rendering in a before_action immediately stops the action chain, and since slimmer usually calls slimmer_template as an after_action, it would be skipped over (and you'd get the default layout). 
+
 ## Logging
 
 Slimmer can be configured with a logger by passing in a logger instance


### PR DESCRIPTION
Slimmer doesn't play nicely with renders called from before_actions (it usually sets the headers that allow it to decide on a template as an after_action method, which won't get called if you render in a before_action).

Add a note to explain what to do to work around this.