### PR TITLE
Release version 18.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# Unreleased
+# 18.0.0
 
-* Drop support for determining Rails < 6 application names
+* BREAKING: Drop support for determining Rails < 6 application names
+* BREAKING: Remove `bin/render_slimmer_error` as a feature - it's expected that this is unused.
 * Require Ruby >= 2.7.0
-* Remove `bin/render_slimmer_error` as a feature - it's expected that this is unused.
+* Resolve deprecation warning for Plek.current
 
 # 17.0.0
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "17.0.0".freeze
+  VERSION = "18.0.0".freeze
 end


### PR DESCRIPTION
The changes for this felt like rather soft breaking changes so I've marked it as a major version.

I've also added a note for Plek.current since that might be of interest to updaters.