### PR TITLE
Decorate inline script elements with CSP nonce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Decorate inline script elements with nonce attribute for appropriately configured Rails requests
+
 # 18.0.0
 
 * BREAKING: Drop support for determining Rails < 6 application names

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -38,6 +38,7 @@ module Slimmer
     autoload :ConditionalCommentMover, "slimmer/processors/conditional_comment_mover"
     autoload :FeedbackURLSwapper, "slimmer/processors/feedback_url_swapper"
     autoload :MetadataInserter, "slimmer/processors/metadata_inserter"
+    autoload :NonceInserter, "slimmer/processors/nonce_inserter"
     autoload :HeaderContextInserter, "slimmer/processors/header_context_inserter"
     autoload :InsideHeaderInserter, "slimmer/processors/inside_header_inserter"
     autoload :SearchPathSetter, "slimmer/processors/search_path_setter"

--- a/lib/slimmer/processors/nonce_inserter.rb
+++ b/lib/slimmer/processors/nonce_inserter.rb
@@ -1,0 +1,21 @@
+module Slimmer::Processors
+  class NonceInserter
+    def initialize(env)
+      # As Rails is an optional dependency of this gem quietly do nothing if Rails
+      # classes don't exist.
+      @nonce = if defined?(ActionDispatch::Request)
+                 ActionDispatch::Request.new(env).content_security_policy_nonce
+               end
+    end
+
+    def filter(_src, dest)
+      return unless @nonce
+
+      # Add the nonce attribute to script elements that don't have a src attribute
+      # we expect those with src to be on a CSP host allow list
+      dest.css("script:not([src])").each do |script|
+        script["nonce"] = @nonce
+      end
+    end
+  end
+end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -104,6 +104,7 @@ module Slimmer
       template_wrapper_id = "wrapper" # All templates in Static use `#wrapper`
 
       processors = [
+        Processors::NonceInserter.new(source_request.env), # for security, this needs to be run before any application HTML is inserted
         Processors::TitleInserter.new,
         Processors::TagMover.new,
         Processors::ConditionalCommentMover.new,

--- a/test/processors/nonce_inserter_test.rb
+++ b/test/processors/nonce_inserter_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class NonceInserterTest < MiniTest::Test
+  def test_decorates_an_inline_script_element
+    request_env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request_env[ActionDispatch::ContentSecurityPolicy::Request::NONCE_GENERATOR] = ->(_) { "123456" }
+
+    template = as_nokogiri("<html><script>document.write('hello')</script></html>")
+    Slimmer::Processors::NonceInserter.new(request_env).filter(as_nokogiri(""), template)
+
+    assert_equal %{<script nonce="123456">document.write('hello')</script>}, template.at_css("script").to_s
+  end
+
+  def test_doesnt_decorate_a_script_element_with_a_src
+    request_env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request_env[ActionDispatch::ContentSecurityPolicy::Request::NONCE_GENERATOR] = ->(_) { "123456" }
+
+    template = as_nokogiri(%(<html><script src="/script.js"></script></html>))
+    Slimmer::Processors::NonceInserter.new(request_env).filter(as_nokogiri(""), template)
+
+    assert_equal %(<script src="/script.js"></script>), template.at_css("script").to_s
+  end
+
+  def test_doesnt_decorate_an_inline_script_element_without_a_nonce_generator
+    request_env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request_env[ActionDispatch::ContentSecurityPolicy::Request::NONCE_GENERATOR] = nil
+
+    template = as_nokogiri("<html><script>document.write('hello')</script></html>")
+    Slimmer::Processors::NonceInserter.new(request_env).filter(as_nokogiri(""), template)
+
+    assert_equal "<script>document.write('hello')</script>", template.at_css("script").to_s
+  end
+
+  def test_doesnt_decorate_an_inline_script_element_when_rails_isnt_available
+    # Utilise the Object.remove_const private method to temporarily unset a constant
+    # This needs to be re-set at the end of the test otherwise it will impact
+    # other tests.
+    const_value = ActionDispatch.send(:remove_const, :Request)
+
+    request_env = Rack::MockRequest.env_for("https://new-example.com/new_path")
+    request_env[ActionDispatch::ContentSecurityPolicy::Request::NONCE_GENERATOR] = ->(_) { "123456" }
+
+    template = as_nokogiri("<html><script>document.write('hello')</script></html>")
+    Slimmer::Processors::NonceInserter.new(request_env).filter(as_nokogiri(""), template)
+
+    assert_equal "<script>document.write('hello')</script>", template.at_css("script").to_s
+    ActionDispatch.const_set(:Request, const_value)
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

We aspire [1] to use the GOV.UK Content Security Policy to only allow inline script elements on GOV.UK with the use of a nonce attribute [2]. This is to prevent cross-site-scripting in compliant browsers.

A challenge we have is that a rendering application (e.g. Frontend) may have inline scripts and a template provided by static may also have inline scripts and we need these to agree on the same nonce.

This change updates slimmer so that it will apply an applications nonce within HTML returned by static. Static will not set any nonce attributes.

For security, we need to run the NonceInserter processor before we Slimmer inserts any HTML from an app. As otherwise, in a scenario where someone found an ability to embed HTML in an app, this could mean we inadvertently set a nonce on an XSS attempt. However if we run this before any changes have been made to the template we can trust that it's just as static provided it.

This approach depends on the availability of Rails (for the availability of ActionDispatch::Request) which is an optional dependency of this gem. I can't imagine a scenario currently where GOV.UK would be using this nonce functionality without Rails so I've set the code to just fallback quietly if used without Rails.

[1]: https://github.com/alphagov/govuk_app_config/blob/8680b784615339eadd6f716f35c7d0cad904bed1/lib/govuk_app_config/govuk_content_security_policy.rb#L55-L59
[2]: https://content-security-policy.com/nonce/