### PR TITLE
Release 18.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.1.0
 
 * Decorate inline script elements with nonce attribute for appropriately configured Rails requests
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.0.0".freeze
+  VERSION = "18.1.0".freeze
 end


### PR DESCRIPTION
This includes the ability to decorate inline script tag with nonce attributes for applications that use a Content Security Policy nonce.