### PR TITLE
Update from Nokogiri::HTML to Nokogiri::HTML5

### DIFF
--- a/lib/slimmer/processors/body_class_copier.rb
+++ b/lib/slimmer/processors/body_class_copier.rb
@@ -2,7 +2,7 @@ module Slimmer::Processors
   class BodyClassCopier
     def filter(src, dest)
       src_body_tag = src.at_css("body")
-      dest_body_tag = dest.at_css("body")
+      dest_body_tag = dest.at_css("body-test")
       if src_body_tag.has_attribute?("class")
         combinded_classes = dest_body_tag.attr("class").to_s.split(/ +/)
         combinded_classes << src_body_tag.attr("class").to_s.split(/ +/)

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -1,6 +1,6 @@
 module Slimmer::Processors
   class BodyInserter
-    def initialize(source_id = "wrapper", destination_id = "wrapper", headers = {})
+    def initialize(source_id = "wrapper", destination_id = "wrapper-test", headers = {})
       @source_selector = "##{source_id}"
       @destination_selector = "##{destination_id}"
       @headers = headers

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -14,7 +14,7 @@ module Slimmer::Processors
       css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
       css_classes << destination_markup.attributes["class"].to_s.split(/ +/) if destination_markup.has_attribute?("class")
 
-      body = Nokogiri::HTML.fragment(source_markup.to_html)
+      body = Nokogiri::HTML5.fragment(source_markup.to_html)
       dest.at_css(@destination_selector).replace(body)
       dest.at_css(@destination_selector).set_attribute("class", css_classes.flatten.uniq.join(" ")) if is_gem_layout? && css_classes.any?
     end

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -14,7 +14,10 @@ module Slimmer::Processors
       css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
       css_classes << destination_markup.attributes["class"].to_s.split(/ +/) if destination_markup.has_attribute?("class")
 
-      body = Nokogiri::HTML5.fragment(source_markup.to_html)
+      body = Nokogiri::HTML5.fragment(source_markup.to_html, max_errors: 10)
+      body.errors.each do |err|
+        puts(err)
+      end
       dest.at_css(@destination_selector).replace(body)
       dest.at_css(@destination_selector).set_attribute("class", css_classes.flatten.uniq.join(" ")) if is_gem_layout? && css_classes.any?
     end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -47,7 +47,10 @@ module Slimmer
     end
 
     def parse_html(html, description_for_error_message)
-      doc = Nokogiri::HTML5.parse(html)
+      doc = Nokogiri::HTML5.parse(html, max_errors: 10)
+      doc.errors.each do |err|
+        puts(err)
+      end
       if strict
         errors = doc.errors.select(&:error?).reject { |e| ignorable?(e) }
         unless errors.empty?

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -47,7 +47,7 @@ module Slimmer
     end
 
     def parse_html(html, description_for_error_message)
-      doc = Nokogiri::HTML.parse(html)
+      doc = Nokogiri::HTML5.parse(html)
       if strict
         errors = doc.errors.select(&:error?).reject { |e| ignorable?(e) }
         unless errors.empty?


### PR DESCRIPTION
Using HTML5 based markup, such as self-closing tags, get parsed into invalid HTML. This attempts to fix an issue we encountered [1]

[1]: https://github.com/alphagov/slimmer/issues/301