### PR TITLE
Update reference to deprecated Rack::Utils::HeaderHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Drop support for Ruby 2.7.
+* Update reference to deprecated Rack::Utils::HeaderHash
 
 # 18.1.0
 

--- a/lib/slimmer/app.rb
+++ b/lib/slimmer/app.rb
@@ -42,7 +42,7 @@ module Slimmer
     end
 
     def response_can_be_rewritten?(status, headers)
-      Rack::Utils::HeaderHash.new(headers)["Content-Type"] =~ /text\/html/ && ![301, 302, 304].include?(status)
+      Rack::Headers.new.merge(headers)["Content-Type"] =~ /text\/html/ && ![301, 302, 304].include?(status)
     end
 
     def skip_slimmer?(env, response)
@@ -93,9 +93,7 @@ module Slimmer
     end
 
     def strip_slimmer_headers(headers)
-      # Convert Rack::Util::HeaderHash to a simple hash to avoid a Ruby warning
-      # of extra states not copied. Can be removed once Ruby < 3.1 support is removed.
-      headers.to_h.reject { |k, _v| k =~ /\A#{Headers::HEADER_PREFIX}/ }
+      headers.reject { |k, _v| k =~ /\A#{Headers::HEADER_PREFIX}/i }
     end
   end
 end


### PR DESCRIPTION
References to Rack::Utils::HeaderHash now causing deprecation methods in email-alert-frontend. Replace with Rack::Headers, and remove unneeded to_h call.

Upgrade guide for Rack: https://github.com/rack/rack/blob/64610db2d2e7e910c4d3e17874dc316ed3eb227a/UPGRADE-GUIDE.md?plain=1#L237-L285

Example deprecation warning from test suite:

`/root/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/slimmer-18.1.0/lib/slimmer/app.rb:45: warning: Rack::Utils::HeaderHash is deprecated and will be removed in Rack 3.1, switch to Rack::Headers`

