### PR TITLE
Release 18.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 18.4.0
+
+* Drop support for Ruby 3.0. Ruby 3.2 is now required.
+
 # 18.3.0
 
 * Enforce requirement for Rack 3

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.3.0".freeze
+  VERSION = "18.4.0".freeze
 end


### PR DESCRIPTION
#316 - Upgrade minimum Ruby version to 3.2. Ruby 3.0 and 3.1 support has been removed.