### PR TITLE
Raise more specific error when wrapper not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Raise more specific error when wrapper not found
+* Raise more specific error when wrapper not found. This will only be active when the host app has SLIMMER_WRAPPER_CHECK=true set in the host app's environment.
 
 # 18.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Raise more specific error when wrapper not found
+
 # 18.4.0
 
 * Drop support for Ruby 3.0. Ruby 3.2 is now required.

--- a/lib/slimmer.rb
+++ b/lib/slimmer.rb
@@ -51,4 +51,5 @@ module Slimmer
   class CouldNotRetrieveTemplate < StandardError; end
   class TemplateNotFoundException < CouldNotRetrieveTemplate; end
   class IntermittentRetrievalError < CouldNotRetrieveTemplate; end
+  class SourceWrapperNotFoundError < StandardError; end
 end

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -10,6 +10,8 @@ module Slimmer::Processors
       source_markup = src.at_css(@source_selector)
       destination_markup = dest.at_css(@destination_selector)
 
+      raise(Slimmer::SourceWrapperNotFoundError, "Source wrapper div not found", caller) if source_markup.nil?
+
       css_classes = []
       css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
       css_classes << destination_markup.attributes["class"].to_s.split(/ +/) if destination_markup.has_attribute?("class")

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -10,7 +10,7 @@ module Slimmer::Processors
       source_markup = src.at_css(@source_selector)
       destination_markup = dest.at_css(@destination_selector)
 
-      raise(Slimmer::SourceWrapperNotFoundError, "Source wrapper div not found", caller) if source_markup.nil?
+      raise(Slimmer::SourceWrapperNotFoundError, "Source wrapper div not found", caller) if source_markup.nil? && wrapper_check?
 
       css_classes = []
       css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
@@ -25,6 +25,10 @@ module Slimmer::Processors
 
     def is_gem_layout?
       @headers[Slimmer::Headers::TEMPLATE_HEADER]&.start_with?("gem_layout")
+    end
+
+    def wrapper_check?
+      ENV["SLIMMER_WRAPPER_CHECK"] == "true"
     end
   end
 end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -122,6 +122,12 @@ module Slimmer
 
       template_name = response.headers[Headers::TEMPLATE_HEADER] || "gem_layout"
       process(processors, body, template(template_name), source_request.env)
+    rescue SourceWrapperNotFoundError => e
+      message = "#{e.message} "\
+                "at: #{source_request.base_url}#{source_request.path} "\
+                "length: #{body.to_s.length} "\
+                "html: #{body.to_s[0, 300].match?(/<html>/i)}"
+      raise SourceWrapperNotFoundError, message, caller
     end
   end
 end

--- a/test/processors/body_inserter_test.rb
+++ b/test/processors/body_inserter_test.rb
@@ -1,15 +1,35 @@
 require "test_helper"
 
 class BodyInserterTest < Minitest::Test
-  def test_should_raise_source_wrapper_div_not_found_error_when_wrapper_not_found
+  def test_should_raise_source_wrapper_div_not_found_error_when_wrapper_not_found_and_env_set
     template = as_nokogiri %(
       <html><body><div><div id="wrapper"></div></div></body></html>
     )
     source = as_nokogiri %(
       <html><body><nav></nav><div><p>this should be moved</p></div></body></html>
     )
-    assert_raises(Slimmer::SourceWrapperNotFoundError) do
-      Slimmer::Processors::BodyInserter.new.filter(source, template)
+
+    ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
+      assert_raises(Slimmer::SourceWrapperNotFoundError) do
+        Slimmer::Processors::BodyInserter.new.filter(source, template)
+      end
+    end
+  end
+
+  def test_should_not_raise_source_wrapper_div_not_found_error_when_wrapper_not_found_and_env_not_set
+    template = as_nokogiri %(
+      <html><body><div><div id="wrapper"></div></div></body></html>
+    )
+    source = as_nokogiri %(
+      <html><body><nav></nav><div><p>this should be moved</p></div></body></html>
+    )
+
+    # NoMethodError is the current fail is source wrapper is missing
+    # it's not good, but we want it to behave the same for now
+    ClimateControl.modify(SLIMMER_WRAPPER_CHECK: nil) do
+      assert_raises(NoMethodError) do
+        Slimmer::Processors::BodyInserter.new.filter(source, template)
+      end
     end
   end
 

--- a/test/processors/body_inserter_test.rb
+++ b/test/processors/body_inserter_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class BodyInserterTest < Minitest::Test
+  def test_should_raise_source_wrapper_div_not_found_error_when_wrapper_not_found
+    template = as_nokogiri %(
+      <html><body><div><div id="wrapper"></div></div></body></html>
+    )
+    source = as_nokogiri %(
+      <html><body><nav></nav><div><p>this should be moved</p></div></body></html>
+    )
+    assert_raises(Slimmer::SourceWrapperNotFoundError) do
+      Slimmer::Processors::BodyInserter.new.filter(source, template)
+    end
+  end
+
   def test_should_replace_contents_of_wrapper_in_template
     template = as_nokogiri %(
       <html><body><div><div id="wrapper"></div></div></body></html>

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -79,6 +79,33 @@ module TypicalUsage
     end
   end
 
+  class EmptyResponseTest < SlimmerIntegrationTest
+    def test_should_raise_source_wrapper_div_not_found_error
+      assert_raises(Slimmer::SourceWrapperNotFoundError) do
+        given_response 200, ""
+      end
+    end
+  end
+
+  class ResponseWithNoWrapperTest < SlimmerIntegrationTest
+    def test_should_raise_source_wrapper_div_not_found_error
+      assert_raises(Slimmer::SourceWrapperNotFoundError) do
+        given_response 200, %(
+          <html>
+          <head><title>The title of the page</title>
+          <meta name="something" content="yes">
+          <script src="blah.js"></script>
+          <link href="app.css" rel="stylesheet" type="text/css">
+          </head>
+          <body class="body_class">
+          <div>The body of the page</div>
+          </body>
+          </html>
+        )
+      end
+    end
+  end
+
   class NormalResponseTest < SlimmerIntegrationTest
     def setup
       super

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -81,27 +81,31 @@ module TypicalUsage
 
   class EmptyResponseTest < SlimmerIntegrationTest
     def test_should_raise_source_wrapper_div_not_found_error
-      assert_raises(Slimmer::SourceWrapperNotFoundError) do
-        given_response 200, ""
+      ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
+        assert_raises(Slimmer::SourceWrapperNotFoundError) do
+          given_response 200, ""
+        end
       end
     end
   end
 
   class ResponseWithNoWrapperTest < SlimmerIntegrationTest
     def test_should_raise_source_wrapper_div_not_found_error
-      assert_raises(Slimmer::SourceWrapperNotFoundError) do
-        given_response 200, %(
-          <html>
-          <head><title>The title of the page</title>
-          <meta name="something" content="yes">
-          <script src="blah.js"></script>
-          <link href="app.css" rel="stylesheet" type="text/css">
-          </head>
-          <body class="body_class">
-          <div>The body of the page</div>
-          </body>
-          </html>
-        )
+      ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
+        assert_raises(Slimmer::SourceWrapperNotFoundError) do
+          given_response 200, %(
+            <html>
+            <head><title>The title of the page</title>
+            <meta name="something" content="yes">
+            <script src="blah.js"></script>
+            <link href="app.css" rel="stylesheet" type="text/css">
+            </head>
+            <body class="body_class">
+            <div>The body of the page</div>
+            </body>
+            </html>
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
## What

When wrapper is not found it results in a method being called on `nil`, which produces `NoMethodError`. For the purposes of investigating the error in the attached Trello card it would be useful to produce a more meaningful error containing some additional information which could help the investigation.

(Have added a feature flag, so this is only active when SLIMMER_WRAPPER_CHECK=true is set in the host app)

## Why

To facilitate the investigation of the error in the [Trello card](https://trello.com/c/iyPxdU09/2495-sentry-errors-investigate-frontend-nomethoderror)