### PR TITLE
Release 18.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.5.0
 
 * Raise more specific error when wrapper not found. This will only be active when the host app has SLIMMER_WRAPPER_CHECK=true set in the host app's environment.
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.4.0".freeze
+  VERSION = "18.5.0".freeze
 end


### PR DESCRIPTION
* Raise more specific error when wrapper not found. This will only be active when the host app has SLIMMER_WRAPPER_CHECK=true set in the host app's environment.