### PR TITLE
Include the initial part of the body in the error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Include a part of the body in the error message text
+
 # 18.5.0
 
 * Raise more specific error when wrapper not found. This will only be active when the host app has SLIMMER_WRAPPER_CHECK=true set in the host app's environment.

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -100,6 +100,7 @@ module Slimmer
     end
 
     def success(source_request, response, body)
+      original_body = body.dup
       wrapper_id = options[:wrapper_id] || "wrapper"
       template_wrapper_id = "wrapper" # All templates in Static use `#wrapper`
 
@@ -125,8 +126,8 @@ module Slimmer
     rescue SourceWrapperNotFoundError => e
       message = "#{e.message} "\
                 "at: #{source_request.base_url}#{source_request.path} "\
-                "length: #{body.to_s.length} "\
-                "html: #{body.to_s[0, 300].match?(/<html>/i)}"
+                "length: #{original_body.to_s.length} "\
+                "body: original_body.to_s[0..2000]"
       raise SourceWrapperNotFoundError, message, caller
     end
   end


### PR DESCRIPTION
## What

A further change related to https://github.com/alphagov/slimmer/pull/321

## Why

The initial investigation discovered that there is indeed some content in the body, but it does not contain a wrapper and it does not contain "\<html\>". This change will allow us to discover the initial part of the contents, so we can better understand what is being returned.


