### PR TITLE
Update SourceWrapperNotFoundError handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Remove the part of the body from the error message for SourceWrapperNotFoundError and do some cleanup
+  Use more explanatory error message. Apply this globally to all apps.
+
 # 18.5.2
 
 * Fix a mistake in 18.5.1

--- a/lib/slimmer/processors/body_inserter.rb
+++ b/lib/slimmer/processors/body_inserter.rb
@@ -10,7 +10,14 @@ module Slimmer::Processors
       source_markup = src.at_css(@source_selector)
       destination_markup = dest.at_css(@destination_selector)
 
-      raise(Slimmer::SourceWrapperNotFoundError, "Source wrapper div not found", caller) if source_markup.nil? && wrapper_check?
+      if source_markup.nil?
+        raise(Slimmer::SourceWrapperNotFoundError, <<~ERROR_MESSAGE, caller)
+          Slimmer did not find a div with ID "wrapper" in the source HTML.
+          This could be because a request was made to your Rails application
+          for a format that it does not support. For example a JavaScript request,
+          when the application only has HTML templates.
+        ERROR_MESSAGE
+      end
 
       css_classes = []
       css_classes << source_markup.attributes["class"].to_s.split(/ +/) if source_markup.has_attribute?("class")
@@ -25,10 +32,6 @@ module Slimmer::Processors
 
     def is_gem_layout?
       @headers[Slimmer::Headers::TEMPLATE_HEADER]&.start_with?("gem_layout")
-    end
-
-    def wrapper_check?
-      ENV["SLIMMER_WRAPPER_CHECK"] == "true"
     end
   end
 end

--- a/lib/slimmer/skin.rb
+++ b/lib/slimmer/skin.rb
@@ -100,7 +100,6 @@ module Slimmer
     end
 
     def success(source_request, response, body)
-      original_body = body.dup
       wrapper_id = options[:wrapper_id] || "wrapper"
       template_wrapper_id = "wrapper" # All templates in Static use `#wrapper`
 
@@ -123,12 +122,6 @@ module Slimmer
 
       template_name = response.headers[Headers::TEMPLATE_HEADER] || "gem_layout"
       process(processors, body, template(template_name), source_request.env)
-    rescue SourceWrapperNotFoundError => e
-      message = "#{e.message} "\
-                "at: #{source_request.base_url}#{source_request.path} "\
-                "length: #{original_body.to_s.length} "\
-                "body: #{original_body.to_s[0..2000]}"
-      raise SourceWrapperNotFoundError, message, caller
     end
   end
 end

--- a/test/processors/body_inserter_test.rb
+++ b/test/processors/body_inserter_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class BodyInserterTest < Minitest::Test
-  def test_should_raise_source_wrapper_div_not_found_error_when_wrapper_not_found_and_env_set
+  def test_should_raise_source_wrapper_div_not_found_error_when_wrapper_not_found
     template = as_nokogiri %(
       <html><body><div><div id="wrapper"></div></div></body></html>
     )
@@ -9,27 +9,8 @@ class BodyInserterTest < Minitest::Test
       <html><body><nav></nav><div><p>this should be moved</p></div></body></html>
     )
 
-    ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
-      assert_raises(Slimmer::SourceWrapperNotFoundError) do
-        Slimmer::Processors::BodyInserter.new.filter(source, template)
-      end
-    end
-  end
-
-  def test_should_not_raise_source_wrapper_div_not_found_error_when_wrapper_not_found_and_env_not_set
-    template = as_nokogiri %(
-      <html><body><div><div id="wrapper"></div></div></body></html>
-    )
-    source = as_nokogiri %(
-      <html><body><nav></nav><div><p>this should be moved</p></div></body></html>
-    )
-
-    # NoMethodError is the current fail is source wrapper is missing
-    # it's not good, but we want it to behave the same for now
-    ClimateControl.modify(SLIMMER_WRAPPER_CHECK: nil) do
-      assert_raises(NoMethodError) do
-        Slimmer::Processors::BodyInserter.new.filter(source, template)
-      end
+    assert_raises(Slimmer::SourceWrapperNotFoundError) do
+      Slimmer::Processors::BodyInserter.new.filter(source, template)
     end
   end
 

--- a/test/typical_usage_test.rb
+++ b/test/typical_usage_test.rb
@@ -81,31 +81,27 @@ module TypicalUsage
 
   class EmptyResponseTest < SlimmerIntegrationTest
     def test_should_raise_source_wrapper_div_not_found_error
-      ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
-        assert_raises(Slimmer::SourceWrapperNotFoundError) do
-          given_response 200, ""
-        end
+      assert_raises(Slimmer::SourceWrapperNotFoundError) do
+        given_response 200, ""
       end
     end
   end
 
   class ResponseWithNoWrapperTest < SlimmerIntegrationTest
     def test_should_raise_source_wrapper_div_not_found_error
-      ClimateControl.modify(SLIMMER_WRAPPER_CHECK: "true") do
-        assert_raises(Slimmer::SourceWrapperNotFoundError) do
-          given_response 200, %(
-            <html>
-            <head><title>The title of the page</title>
-            <meta name="something" content="yes">
-            <script src="blah.js"></script>
-            <link href="app.css" rel="stylesheet" type="text/css">
-            </head>
-            <body class="body_class">
-            <div>The body of the page</div>
-            </body>
-            </html>
-          )
-        end
+      assert_raises(Slimmer::SourceWrapperNotFoundError) do
+        given_response 200, %(
+          <html>
+          <head><title>The title of the page</title>
+          <meta name="something" content="yes">
+          <script src="blah.js"></script>
+          <link href="app.css" rel="stylesheet" type="text/css">
+          </head>
+          <body class="body_class">
+          <div>The body of the page</div>
+          </body>
+          </html>
+        )
       end
     end
   end


### PR DESCRIPTION
## What

We keep getting the following exception in production: https://govuk.sentry.io/issues/4958108827/?environment=production&environment=production-eks&environment=producton&project=-1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=9

After [the discussion](https://gds.slack.com/archives/C052X8S2P8A/p1718796354165479) there was a suggestion to keep the SourceWrapperNotFoundError instead of reverting the PRs introducing it. I have removed the parts which were only meant to be used in the investigation of the issue and added a more explanatory message, so the issue is understood immediately after seeing the error. It cleans up after: https://github.com/alphagov/slimmer/pull/321, https://github.com/alphagov/slimmer/pull/330 and https://github.com/alphagov/slimmer/pull/332.

There is a separate [PR](https://github.com/alphagov/govuk_app_config/pull/383) in govuk_app_config which excludes SourceWrapperNotFoundError from being sent to Sentry.

## Why

[Trello ticket](https://trello.com/c/iyPxdU09/2495-sentry-errors-investigate-fix-frontend-nomethoderror)

## Testing

A branch of frontend including this change and the govuk_app_config change has been pushed to integration. E. g. the following request https://www.integration.publishing.service.gov.uk/renew-driving-licence-at-70/something_funny_to_put_into_the_error_message.js doesn't sent the error to Sentry, but the error is generated and visible in the logs.