### PR TITLE
Update body classes for govuk frontend v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Update body classes for govuk-frontend-v5
+
 # 18.6.0
 
 * Remove the part of the body from the error message for SourceWrapperNotFoundError and do some cleanup

--- a/lib/slimmer/test_templates/header_footer_only.html
+++ b/lib/slimmer/test_templates/header_footer_only.html
@@ -3,7 +3,7 @@
     <title>Test Template</title>
   </head>
   <body>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
     <header id="global-header">
       <div class="header-wrapper"></div>

--- a/lib/slimmer/test_templates/wrapper.html
+++ b/lib/slimmer/test_templates/wrapper.html
@@ -3,7 +3,7 @@
     <title>Test Template</title>
   </head>
   <body>
-    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+    <script>document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');</script>
 
     <header id="global-header">
       <div class="header-wrapper"></div>


### PR DESCRIPTION
## What

Update the `<script>` snippet in the test templates.

## Why

For govuk-frontend v5, there now needs to be additional class added to the `body` tag to indicate that the components are supported.

This class is `govuk-frontend-supported` and is added if the browser supports JS of type `module` (which is the new browser target for govuk-frontend).

The script tag is directly taken from the documentation, see "Update the `<script>` snippet at the top of your `<body>` tag" in the [release notes for govuk-frontend 5.0.0](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0)

We can safely move to the new snippet in advance of upgrading to V5 of govuk-frontend and ensure components from govuk-frontend still initialise as expect when running integration tests from apps such as smart-answers.

[Trello card](https://trello.com/c/ckhhAD9v/2543-complete-browser-testing-of-smart-answers)