### PR TITLE
Release 18.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.6.0
 
 * Remove the part of the body from the error message for SourceWrapperNotFoundError and do some cleanup
   Use more explanatory error message. Apply this globally to all apps.

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.5.2".freeze
+  VERSION = "18.6.0".freeze
 end


### PR DESCRIPTION
* Remove the part of the body from the error message for SourceWrapperNotFoundError and do some cleanup Use more explanatory error message. Apply this globally to all apps.