### PR TITLE
Release 18.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.6.1
 
 * Update body classes for govuk-frontend-v5
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.6.0".freeze
+  VERSION = "18.6.1".freeze
 end


### PR DESCRIPTION
# 18.6.1

* Update body classes for govuk-frontend-v5 - ([PR #337](https://github.com/alphagov/slimmer/pull/337))