### PR TITLE
Remove 'analytics' from metatags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Remove 'analytics' from metatags
+
 # 18.6.1
 
 * Update body classes for govuk-frontend-v5

--- a/lib/slimmer/processors/metadata_inserter.rb
+++ b/lib/slimmer/processors/metadata_inserter.rb
@@ -8,8 +8,11 @@ module Slimmer::Processors
     def filter(_old_doc, new_doc)
       head = new_doc.at_css("head")
 
+      # temporarily duplicate these tags with the old names to avoid deployment issues
       add_meta_tag("analytics:organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head, new_doc)
       add_meta_tag("analytics:world-locations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head, new_doc)
+      add_meta_tag("organisations", @headers[Slimmer::Headers::ORGANISATIONS_HEADER], head, new_doc)
+      add_meta_tag("world-locations", @headers[Slimmer::Headers::WORLD_LOCATIONS_HEADER], head, new_doc)
       add_meta_tag("format", @headers[Slimmer::Headers::FORMAT_HEADER], head, new_doc)
       add_meta_tag("search-result-count", @headers[Slimmer::Headers::RESULT_COUNT_HEADER], head, new_doc)
       add_meta_tag("rendering-application", @app_name, head, new_doc)

--- a/test/processors/metadata_inserter_test.rb
+++ b/test/processors/metadata_inserter_test.rb
@@ -45,11 +45,11 @@ module MetadataInserterTest
     end
 
     def test_should_include_organisations_meta_tag
-      assert_meta_tag "analytics:organisations", "<P1><D422>"
+      assert_meta_tag "organisations", "<P1><D422>"
     end
 
     def test_should_include_world_locations_meta_tag
-      assert_meta_tag "analytics:world-locations", "<WL3>"
+      assert_meta_tag "world-locations", "<WL3>"
     end
 
     def test_should_include_search_result_count_meta_tag
@@ -71,11 +71,11 @@ module MetadataInserterTest
     end
 
     def test_should_omit_organisations
-      refute_meta_tag "analytics:organisations"
+      refute_meta_tag "organisations"
     end
 
     def test_should_omit_world_locations
-      refute_meta_tag "analytics:world-locations"
+      refute_meta_tag "world-locations"
     end
 
     def test_should_omit_result_count


### PR DESCRIPTION
## What
Rename two of our metatags to remove `analytics` from them.

Must be deployed with: https://github.com/alphagov/govuk_publishing_components/pull/4222

## Why
Making them consistent with other metatags - we don't include `analytics` for other tags, even though they're used by analytics.

## Visual changes
None.

Trello card: https://trello.com/c/lIVmnFpY/336-page-view-enhancement-some-meta-tags-start-with-analytics
