### PR TITLE
Version 18.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.6.2
 
 * Remove 'analytics' from metatags
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.6.1".freeze
+  VERSION = "18.6.2".freeze
 end


### PR DESCRIPTION
# 18.6.2

* Remove 'analytics' from metatags