### PR TITLE
Release 18.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 18.7.0
 
 * Use Ruby 3.3 as default https://github.com/alphagov/slimmer/pull/348
 

--- a/lib/slimmer/version.rb
+++ b/lib/slimmer/version.rb
@@ -1,3 +1,3 @@
 module Slimmer
-  VERSION = "18.6.2".freeze
+  VERSION = "18.7.0".freeze
 end


### PR DESCRIPTION
* Use Ruby 3.3 as default https://github.com/alphagov/slimmer/pull/348